### PR TITLE
Add GitLab Pipelines by puzl.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Github actions](https://github.com/features/actions) - GitHub Actions makes it easy to automate all your software workflows, now with world-class CI/CD.
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.
+  - [GitLab Pipelines by puzl.cloud](https://gitlab-pipelines.puzl.cloud) - Blazing-fast, cost-effective execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
 
 ## Source Code Management
 


### PR DESCRIPTION
[Puzl](https://puzl.cloud) is a modern cloud platform focusing on cost-effective runtime. You can run cloud workloads and pay for their pure CPU and memory consumption, not for the idle of cloud instances. In this request, I submit our new SaaS service for running GitLab CI/CD pipelines.