### PR TITLE
Add Cloud Native Playground to Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,10 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 
 Basic understanding and what you should know to become a *DevOps* Engineer, check the roadmap [here](https://roadmap.sh/devops).
 
+### Online Platforms
+
+- [Cloud Native Playground](https://play.meshery.io) - The Meshery CNCF Playground is an awesome and free resource featuring a live Kubernetes cluster where any CNCF project can be configured and deployed. It is a fantastic interactive learning platform for exploring cloud native technologies.
+
 ## Contributing
 
 Your contributions are always welcome! Please take a look at the [Contribution Guidelines](https://github.com/wmariuss/awesome-devops/blob/main/docs/contribution.md).


### PR DESCRIPTION
This pull request Cloud Native Playground to the Resources section:

- [Cloud Native Playground](https://play.meshery.io) - The Meshery CNCF Playground is an awesome and free resource featuring a live Kubernetes cluster where any CNCF project can be configured and deployed. It is a fantastic interactive learning platform for exploring cloud native technologies.