### PR TITLE
Add gitlab-self-healing-pipeline to CI/CD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Tekton](https://tekton.dev/) - powerful and flexible open-source framework for creating CI/CD systems.
   - [PipeCD](https://pipecd.dev/) - Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications.
   - [Dagger](https://dagger.io/) - CI/CD as Code that Runs Anywhere.
+  - [gitlab-self-healing-pipeline](https://github.com/thirug/gitlab-self-healing-pipeline) – A self-healing GitLab CI/CD framework that auto-resumes from failed stages using progress tracking and cron-based recovery.
 - Public Services
   - [Travis CI](https://travis-ci.org/) - easily sync your projects, you’ll be testing your code in minutes.
   - [Circle CI](https://circleci.com/) - powerful CI/CD pipelines that keep code moving.


### PR DESCRIPTION

## Project submission: gitlab-self-healing-pipeline

**Repository URL:**  
https://github.com/thirug/gitlab-self-healing-pipeline

**Project Name:**  
GitLab Self-Healing Pipeline

**Short Description:**  
A self-healing CI/CD automation framework for GitLab that automatically resumes pipeline execution from the last successful stage on runner disconnect, stuck jobs, or flaky execution.

**Key Features:**
- Resume pipeline from last known stage with RESUME_STAGE support
- Per-pipeline progress tracking via `.ci-progress.json`
- Retry limits, stage age cutoff, and stuck job detection
- Cronjob-compatible watchdog (Linux & Kubernetes)
- Includes documentation, usage guide, issue templates, and enhancement roadmap

**Topics / Tags:**  
`gitlab`, `ci-cd`, `devops`, `self-healing`, `automation`, `watchdog`, `resilience`, `gitlab-runner`

**License:**  
MIT License

**Why it's awesome:**  
This tool brings production-grade resilience to GitLab pipelines by minimizing manual intervention and saving hours of developer time.  
It’s built with OSS best practices, is easily extensible, and works in distributed team environments with GitLab runners running across clouds or VMs.

---

Looking forward to contributing this to the awesome-devops list!
