### PR TITLE
Add Telert to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *All the tools, services which increase productivity, developer velocity and developer experience.*
 
 - [tenv](https://github.com/tofuutils/tenv) - streamline IaC version manager for OpenTofu, Terraform, Terragrunt and Atmos, written in Go.
+- [Telert](https://github.com/navig-me/telert) - Get alerts when terminal commands finish via Telegram, Slack, Audio, etc.
 - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management.
 - [tfenv](https://github.com/tfutils/tfenv) - Terraform version manager.
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.


### PR DESCRIPTION
Added [Telert](https://github.com/navig-me/telert) to the Productivity Tools section.

Telert is a lightweight CLI tool that sends alerts (Telegram, Slack, Desktop, Audio) when terminal commands finish. It helps improve developer productivity by notifying users after long-running jobs complete.
