### PR TITLE
Add gah - an GitHub Releases app installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *Builds packages in isolation from each other.*
 
 - [Nix/NixOS](https://nixos.org/) - A tool that takes a unique approach to package management and system configuration.
+- [gah](https://github.com/marverix/gah) - A tool that makes installing apps from GitHub Releases much faster and less monotonic.
 
 ## Distributed Filesystems
 


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.