### PR TITLE
Add Buildstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.
   - [GitLab Pipelines by puzl.cloud](https://puzl.cloud/products/run-my-job/) - Blazing-fast, cost-effective execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
+  - [Buildstash](https://buildstash.com) - Archive built software binaries, distribute to testers, and deploy releases to distribution platforms.
 
 ## Source Code Management
 


### PR DESCRIPTION
This arguably could fit better under a "Binary Artifact Management" or similar category, but there isn't one right now and would overlap with existing "Container Image Registry" items.

Also fits under CD so added it there.