### PR TITLE
Add Unleash to Continuous Integration & Delivery section (open source feature flagging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Tekton](https://tekton.dev/) - powerful and flexible open-source framework for creating CI/CD systems.
   - [PipeCD](https://pipecd.dev/) - Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications.
   - [Dagger](https://dagger.io/) - CI/CD as Code that Runs Anywhere.
+  - [Unleash](https://www.getunleash.io) - Open-source feature management platform (feature flags, gradual rollouts, A/B testing) to decouple deploy from release.
 - Public Services
   - [Travis CI](https://travis-ci.org/) - easily sync your projects, you’ll be testing your code in minutes.
   - [Circle CI](https://circleci.com/) - powerful CI/CD pipelines that keep code moving.


### PR DESCRIPTION
Reasoning: Unleash helps you decouple deploy from release, enabling continuous delivery practices.