### PR TITLE
Add glnk.dev - Go-links for cloud consoles

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management.
 - [tfenv](https://github.com/tfutils/tfenv) - Terraform version manager.
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
+- [glnk.dev](https://glnk.dev) - Personal go-links service with free subdomains. Includes public shortcuts for [AWS](https://aws.glnk.dev) and [GCP](https://gcp.glnk.dev) consoles.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
## What is this?

[glnk.dev](https://glnk.dev) is a free go-links service for DevOps/SRE teams.

### Public shortcuts included:
- `aws.glnk.dev/s3` → S3 Console
- `aws.glnk.dev/ec2` → EC2 Console  
- `gcp.glnk.dev/gke` → GKE Console
- `gcp.glnk.dev/bq` → BigQuery Console
- ... 50+ more with region/project support

### Personal subdomains:
Anyone can get `yourname.glnk.dev` for free to create custom shortcuts.

### Why it's useful:
- Works on mobile (no app needed)
- Memorable URLs instead of bookmarks
- Dynamic parameters (`aws.glnk.dev/ec2/us-west-2`)
- Open source: https://github.com/glnk-dev

---

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] The link is not a duplicate
- [x] The link is useful for DevOps practitioners