### PR TITLE
Add kubefwd to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management.
 - [tfenv](https://github.com/tfutils/tfenv) - Terraform version manager.
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
+- [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
kubefwd is a CLI tool for bulk-forwarding Kubernetes services to localhost. Each service gets a unique loopback IP (127.x.x.x), enabling multiple services on the same port without conflicts.

Repository: https://github.com/txn2/kubefwd