### PR TITLE
Add whatbroke.today - AI-powered outage aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Kibana](https://www.elastic.co/products/kibana) - Explore, visualize, discover data.
   - [Loki](https://github.com/grafana/loki) - Horizontally-scalable, highly available, multi-tenant log aggregation system inspired by Prometheus.
 - Status
+  - [whatbroke.today](https://whatbroke.today) - AI-powered outage aggregator tracking 100+ services with Telegram alerts.
   - [Cachet](https://github.com/CachetHQ/Cachet) - Beautiful and powerful open-source status page system.
   - [StatusPal](https://statuspal.io/?utm_source=github.com&utm_medium=referral&utm_campaign=awesome-devops) - Communicate incidents and maintenance effectively with a beautiful hosted status page.
   - [Instatus](https://instatus.com) - Quick and beautiful status page.


### PR DESCRIPTION
## Description

Adding [whatbroke.today](https://whatbroke.today) to the Status section under Observability & Monitoring.

## What is whatbroke.today?

- **AI-powered** outage aggregator tracking 100+ cloud services
- **Real-time alerts** via Telegram channel (@whatbroketoday)
- **AI summaries** of incidents for quick understanding
- **RSS feed** for DevOps workflows
- **Free** to use

## Why add it?

Unlike traditional status pages that show a single service, whatbroke.today aggregates outages from AWS, Vercel, Stripe, GitHub, Cloudflare, and 100+ other services in one place.

Thanks for maintaining this awesome list!