### PR TITLE
Add Kunobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
+- [Kunobi](https://kunobi.ninja) - Rust Kubernetes management from your desktop, with built-in MCP server.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
## What is Kunobi?

[Kunobi](https://kunobi.ninja) is a desktop platform management IDE. GitOps, simplified.

Built with Rust and React, it provides real-time visual oversight of your Kubernetes clusters, FluxCD, ArgoCD, and Helm — a single pane of glass for platform engineers.

**Key features:**

- Real-time cluster visibility with resource browser, YAML editor, and embedded terminal
- Native FluxCD, ArgoCD, and Helm support
- Built-in MCP server for AI assistants (Claude Code, Codex CLI, Gemini CLI)
- Available on macOS, Windows, and Linux
- No account required, no cloud dependency

![Kunobi](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/main.png)

![Kunobi — Cluster view](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/nodes.png)

**Built-in MCP support:**

Kunobi has an embedded MCP HTTP server. Enable it in Settings > AI & MCP, and AI assistants can manage your clusters while you maintain full visual oversight.

![Kunobi — MCP settings](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/mcp.png)

**Website:** https://kunobi.ninja
**npm:** [@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp)