### PR TITLE
Add Yundera to Applications Platforms 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Canine](https://canine.sh/) - Deploy applications to Kubernetes as easily as deploying to Heroku
 - [vCluster](https://vcluster.sh/)- A open source project that helps you create virtual clusters.
 - [devpod](https://https://devpod.sh/) - Open-source, codebases-like tool that creates reproducible developer environments, supporting numerous providers (Kubernetes, AWS, GCP, etc.).
+- [Yundera](https://www.yundera.com/) ([GitHub](https://github.com/Yundera/casa-img)) - Personal cloud server platform that helps you own your data and easily deploy open source applications, from WordPress and AI tools to file sharing solutions.
 
 ## Internal Developer Platforms
 


### PR DESCRIPTION
Adding Yundera to the Applications Platforms section.

## What is Yundera?
- Personal cloud server platform for self-hosting open source applications
- Pre-configured setup with domain, routing, and security
- Easy deployment of WordPress, AI tools (Llama, Deepseek), and file sharing solutions
- Data ownership and privacy-focused
- Scalable resources with flexible pricing
- Integrates with CasaOS for container management

## Why add it?
Yundera simplifies self-hosting for individuals and teams who want to own their data and run open source applications without complex infrastructure setup. It bridges the gap between traditional PaaS platforms and full self-hosting solutions.

Thanks for maintaining this awesome list!
