### PR TITLE
Add RADP Bash Framework and RADP Vagrant Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Terrateam](https://terrateam.io) - Open-source alternative to Terraform Cloud/Enterprise, GitOps-first with native GitHub integration and designed for scale, security, and reliability.
 - [Scalr](https://scalr.com/) - Drop-in Terraform Cloud alternative, usage-based pricing, unlimited concurrency.
 - [CloudRay](https://cloudray.io) - Centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.
+- [RADP Bash Framework](https://github.com/xooooooooox/radp-bash-framework) - Modular Bash framework for CLI apps with annotation-driven commands.
+- [RADP Vagrant Framework](https://github.com/xooooooooox/radp-vagrant-framework) - YAML-driven multi-machine Vagrant management with config inheritance.
 
 ## Productivity Tools
 


### PR DESCRIPTION
Add two related RADP frameworks to the Automation & Orchestration section:

- **RADP Bash Framework** - Modular Bash framework for CLI apps with annotation-driven commands, scaffolding, 60+ toolkit functions, and multi-platform distribution.
  - https://github.com/xooooooooox/radp-bash-framework (MIT)

- **RADP Vagrant Framework** - YAML-driven framework for managing multi-machine Vagrant environments with configuration inheritance and modular provisioning.
  - https://github.com/xooooooooox/radp-vagrant-framework (MIT)