### PR TITLE
Add CloudVac to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
+- [CloudVac](https://github.com/realadeel/CloudVac) - Scan, inspect, and clean up unused AWS resources across 20 regions with cost estimation and dependency-aware deletion.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
## CloudVac

[CloudVac](https://github.com/realadeel/CloudVac) is a local-only AWS resource scanner and cleanup tool. Added alongside `claws` in the Developer Productivity Tools section.

- Scans **14 services** across **20 AWS regions**
- Per-resource **cost estimation** with regional pricing multipliers
- Identifies **CloudFormation-managed vs. orphaned** resources
- **Dependency-aware deletion** with dry-run safety
- Everything runs locally — no telemetry, no external calls

**Stack:** TypeScript, Express 5, React 19, AWS SDK v3, SQLite
**License:** AGPL-3.0