### PR TITLE
Add Gabe — cron job heartbeat monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Zabbix](https://www.zabbix.com/) - Mature and effortless monitoring solution for network monitoring and application monitoring.
 - [Glances](https://github.com/nicolargo/glances) - Monitoring information through a curses or Web based interface.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - Cron monitoring tool.
+- [Gabe](https://github.com/Scolliq/gabe) - Lightweight cron job heartbeat monitor with webhook alerts, runs on Cloudflare Workers.
 - [Bolo](http://bolo.niftylogic.com/) - Building distributed, scalable monitoring systems.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.


### PR DESCRIPTION
Adds [Gabe](https://github.com/Scolliq/gabe) to the Observability & Monitoring section, next to Healthchecks (which serves a similar purpose).

Gabe is a lightweight cron job heartbeat monitor — you append a curl to your crontab, and if the ping stops arriving, it sends webhook alerts to Slack/Discord.

- Open source (MIT license)
- Self-hostable on Cloudflare Workers free tier
- No database or Docker required
- CLI tool available on npm (`gabe-monitor`)