### PR TITLE
Add ReleaseRun Badges to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [ReleaseRun Badges](https://releaserun.com/badges/) - Version health, EOL countdown, and CVE badges you can embed in dashboards for 300+ products.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
Hey! Adding ReleaseRun Badges under Observability & Monitoring. They provide real-time version health scores, end-of-life countdowns, and CVE severity counts for 300+ products (Kubernetes, Docker, Python, Node.js, etc).

Think of it as version monitoring that lives in your README or dashboard - shows you at a glance whether your stack is current, approaching EOL, or has open CVEs.

Free SVGs, no API key needed. Example badges:

![Python Health](https://img.releaserun.com/badge/health/python.svg) ![K8s CVE](https://img.releaserun.com/badge/cve/kubernetes/1.35.svg) ![Node.js 18 EOL](https://img.releaserun.com/badge/eol/nodejs/18.svg)

Site: https://releaserun.com/badges/