### PR TITLE
Add git-native-issue to Source Code Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Gitblit](https://github.com/gitblit/gitblit) - Pure Java Git solution for managing, viewing, and serving Git repositories.
 - [RhodeCode](https://rhodecode.com/) - Centralized control for distributed repositories. Mercurial, Git, and Subversion under a single roof.
 - [Radicle](https://radicle.xyz/) - Radicle is a sovereign peer-to-peer network for code collaboration, built on top of Git.
+- [git-native-issue](https://github.com/remenoscodes/git-native-issue) - Distributed issue tracking embedded in Git. Track bugs and tasks as native Git objects, sync via push/pull, no server required.
 
 ## Web Servers
 


### PR DESCRIPTION
Adds [git-native-issue](https://github.com/remenoscodes/git-native-issue) to the **Source Code Management** section.

**git-native-issue** is a distributed issue tracking tool embedded in Git:
- Issues stored as native Git objects under `refs/issues/`
- Sync via `git push`/`git pull` — fully offline-first, no server required
- Bridges to GitHub/GitLab for platform interop
- POSIX shell — works on any OS with Git installed
- 282 tests, GPL-2.0 licensed, actively maintained

It complements the existing SCM tools by bringing issue tracking into the Git workflow itself.