### PR TITLE
Add `protoprimer` to "Productivity Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
+- [protoprimer](https://github.com/uvsmtid/protoprimer) - An arg-less script to bootstrap tools in isolated `python` environments in one shot.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
@wmariuss

Hey, what are the entry requirements for a project to be listed?

I want to add `protoprimer`:
https://github.com/uvsmtid/protoprimer
"An arg-less script to bootstrap tools in isolated `python` environments in one shot."

Section ["Productivity Tools"][productivity_tools] seems suitable.

[productivity_tools]: https://github.com/wmariuss/awesome-devops/blob/665b7c2264227efa99e5478abdcae28a0a972008/README.md?plain=1#L189
