### PR TITLE
Add segspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *Validating, lint and best practice in term of Security on code or infrastructure.*
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
+- [segspec](https://github.com/dormstern/segspec) - Generate Kubernetes NetworkPolicies from application config files.
 
 ## Sharing
 


### PR DESCRIPTION
Add [segspec](https://github.com/dormstern/segspec) to the Security section.

segspec is an open-source CLI that generates Kubernetes NetworkPolicies from application config files. MIT license, single Go binary.