### PR TITLE
Add KeyEnv to Secret Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Git Secret](https://github.com/sobolevn/git-secret) - A bash-tool to store your private data inside a git repository.
 - [Infisical](https://github.com/Infisical/infisical) - Open source end-to-end encrypted secrets sync for teams and infrastructure.
 - [Lade](https://github.com/zifeo/lade) - Automatically load secrets from your preferred vault as environment variables.
+- [KeyEnv](https://keyenv.dev) - CLI-first secrets manager that replaces .env files with AES-256 encrypted, team-scoped secrets. Pull credentials locally with one command, zero plaintext on disk.
 - [KeyEnv](https://keyenv.dev) - CLI-first secrets manager for dev teams. Replaces scattered .env files with an encrypted, per-environment store with team access controls and audit trail.
 
 ## Security


### PR DESCRIPTION
## Description

Add [KeyEnv](https://keyenv.dev) to the Secret Management section.

**KeyEnv** is a CLI-first secrets manager for dev teams. It replaces scattered `.env` files with an encrypted, per-environment store. Key features:

- Single command to pull secrets: `keyenv pull`
- AES-256-GCM encryption at rest
- Per-project, per-environment scoping (dev/staging/prod)
- Team access controls and full audit trail
- Zero app code changes needed — works via environment variables

It fits alongside tools like Infisical and Lade in the lightweight secrets management space.