### PR TITLE
Add cloud-audit to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *Validating, lint and best practice in term of Security on code or infrastructure.*
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
+- [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - AWS security auditing CLI that runs 17 checks across IAM, S3, EC2, VPC, and RDS with remediation engine generating AWS CLI commands and Terraform snippets.
 
 ## Sharing
 


### PR DESCRIPTION
Add [cloud-audit](https://github.com/gebalamariusz/cloud-audit) to the Security section.

cloud-audit is an AWS security auditing CLI that runs 17 checks across IAM, S3, EC2, VPC, and RDS. It generates remediation commands (AWS CLI + Terraform) for each finding.

- Open source, Python-based
- Zero config — uses existing AWS credentials
- Outputs prioritized report with actionable fixes