### PR TITLE
Add Agent Gateway to API Gateway section

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *API Gateway, Service Proxy and Service Management tools.*
 
 - [API Umbrella](https://github.com/NREL/api-umbrella) - Proxy that sits in front of your APIs, API management platform.
-- [Agent Gateway](https://github.com/OzorOwn/agent-gateway) - Unified REST API gateway for 39+ AI agent services including crypto, storage, code execution, and more.
+- [Agent Gateway](https://agent-gateway-kappa.vercel.app) - Unified REST API gateway for 39+ AI agent services including crypto, storage, code execution, and more.
 - [Ambassador](https://www.getambassador.io/) - Kubernetes-Native API Gateway built on the Envoy Proxy.
 - [Kong](https://konghq.com/) - Connect all your microservices and APIs with the industry’s most performant, scalable and flexible API platform.
 - [Tyk](https://tyk.io/) - API and service management platform.


### PR DESCRIPTION
Adds [Agent Gateway](https://github.com/OzorOwn/agent-gateway) to the API Gateway section.

Agent Gateway is a unified REST API proxy that routes to 39+ backend microservices through a single endpoint. Services include crypto wallets, DeFi data, code execution, file storage, screenshots, web scraping, and more.

- Single API key for all services
- Built-in rate limiting, authentication, and usage tracking
- OpenAPI 3.1 specs and Swagger UI on every service
- Free tier included