### PR TITLE
Add rootly-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
+- [rootly-cli](https://github.com/rootlyhq/rootly-cli) - Manage Rootly incidents, alerts, services, teams, and on-call schedules from the terminal.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
Add [rootly-cli](https://github.com/rootlyhq/rootly-cli) to Productivity Tools.

**rootly-cli** is an open-source Go CLI for managing Rootly incidents, alerts, services, teams, and on-call schedules from the terminal. It supports multiple output formats (table, JSON, YAML, markdown) and shell completions.