### PR TITLE
Add API Status Check to Observability & Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Steampipe](https://steampipe.io/) - The universal SQL interface for any cloud API, & cloud intelligence dashboards extensible w/ HCL+SQL.
 - [Sensu](https://sensu.io/) - Simple. Scalable. Multi-cloud monitoring.
 - [Alerta](https://github.com/alerta/alerta) - Scalable, minimal configuration and visualization monitoring system.
+- [API Status Check](https://apistatuscheck.com) - Centralized dashboard tracking real-time status and outages for 1,000+ APIs and services. Monitor third-party dependencies, reduce MTTR.
 - [Cabot](https://github.com/arachnys/cabot) - Self-hosted, easily-deployable monitoring and alerts service.
 - [Amon](https://github.com/amonapp/amon) - Modern server monitoring platform.
 - [Icinga](https://icinga.com/) - Monitors availability and performance, gives you simple access to relevant data and raises alerts.


### PR DESCRIPTION
Adding API Status Check (https://apistatuscheck.com) to the Observability & Monitoring section.

API Status Check is a centralized dashboard tracking real-time status and outages for 1,000+ APIs and services including AWS, Stripe, GitHub, Datadog, Twilio, and hundreds more. It helps DevOps and SRE teams:

- Monitor third-party dependencies in real-time
- Quickly identify if issues are internal or caused by external API outages
- Reduce MTTR by eliminating guesswork during incidents
- Get instant outage alerts for critical services

Perfect fit for the Observability & Monitoring section alongside tools like Alerta, Cabot, and Healthchecks.