### PR TITLE
Add repo-intel to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [repo-intel](https://github.com/oxnr/repo-intel) - AI-powered competitive intelligence from GitHub repos as a GitHub Action.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
## Description

Add [repo-intel](https://github.com/oxnr/repo-intel) to the Observability & Monitoring section.

**repo-intel** is an open-source GitHub Action that provides AI-powered competitive intelligence from GitHub repositories. It monitors competitor repos for commit velocity, releases, contributor changes, and strategic signals — delivering reports as GitHub Issues.

## Why it fits

repo-intel complements existing monitoring tools in this section (like Steampipe, Grai, and HolmesGPT) by adding repository-level intelligence and monitoring capabilities as a native GitHub Action.

## Checklist

- [x] Format: `[RESOURCE](LINK) - DESCRIPTION.`
- [x] Description under 80 characters
- [x] Description ends with a full stop
- [x] Individual commit for the category