### PR TITLE
Add Greywall to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *Validating, lint and best practice in term of Security on code or infrastructure.*
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
+- [Greywall](https://github.com/GreyhavenHQ/greywall) - Deny-by-default command sandbox with filesystem and network isolation.
 
 ## Sharing
 


### PR DESCRIPTION
Add [Greywall](https://github.com/GreyhavenHQ/greywall) to the Security section.

Greywall is an open-source, deny-by-default command sandbox for AI coding agents and CLI tools, providing filesystem and network isolation on Linux (bubblewrap + seccomp/Landlock/eBPF) and macOS (sandbox-exec Seatbelt profiles).

Category: Security