### PR TITLE
Add onWatch to Observability & Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Canary Checker](https://canarychecker.io) - Open source health check platform.
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
-- [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [Middleware](https://middleware.io) - A full-stack cloud observability platform.
+- [onWatch](https://github.com/onllm-dev/onwatch) - Track AI API quotas across 6 providers from your terminal.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
Add [onWatch](https://github.com/onllm-dev/onwatch) to the Observability & Monitoring section.

onWatch is an open-source Go CLI that tracks AI API quota usage across 6 providers (Anthropic, OpenAI, GitHub Copilot, Synthetic, Z.ai, Antigravity). It runs as a background daemon with <50MB RAM, uses SQLite for local storage, and includes a Material Design 3 web dashboard. Zero telemetry, zero cloud dependency. GPL-3.0 licensed.