### PR TITLE
add Louisa AI-powered release notes bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
+- [Louisa](https://github.com/arthur-ai/louisa) - AI-powered release notes bot for GitHub and GitLab, generates polished release notes on tag push using Claude.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
## What

Adds [Louisa](https://github.com/arthur-ai/louisa) to the **Productivity Tools** section.

## Why

Louisa is an open-source, AI-powered release notes bot for GitHub and GitLab. Push a tag and it automatically generates polished, user-facing release notes using Claude (Anthropic SDK) — published directly to your Releases page with no manual steps. It fits the section's stated purpose of tools that "increase productivity, developer velocity and developer experience."

Key details:
- Zero-config after setup: push a tag, release notes appear
- Works with GitHub, GitLab, or both simultaneously
- Optional GitHub Actions workflows for monthly blog drafting and changelog publishing
- Deployed on Vercel Serverless Functions (Node.js ES modules)
- MIT licensed, actively maintained