### PR TITLE
Add Super Productivity to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
+- [Super Productivity](https://super-productivity.com) - Open-source task manager and time tracker with Jira, GitHub, and GitLab integration.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
## Summary

Adds [Super Productivity](https://super-productivity.com) to the Productivity Tools section.

- Open-source (MIT), 18k+ GitHub stars, actively maintained since 2016
- Task management and time tracking with built-in integrations for Jira, GitHub, GitLab, and Linear
- Fits naturally alongside the other productivity tools in this list