### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Docker Swarm](https://github.com/docker/swarm) - Docker-native clustering system.
 - [Kubernetes](https://kubernetes.io/) - Automating deployment, scaling, and management of containerized applications.
 - [LXC](https://linuxcontainers.org/) - Lets Linux users easily create and manage system or application containers.
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container management tool built natively on Apple's Containerization framework for macOS.
 - [Rancher](https://rancher.com/) - Lets you deliver Kubernetes-as-a-Service.
 - [OpenVz](https://openvz.org/) - Container-based virtualization for Linux.
 - [Singularity](https://sylabs.io/singularity/) - Run the application from the local environment to the cloud.


### PR DESCRIPTION
## What is Mocker?

[Mocker](https://github.com/us/mocker) is a Docker-compatible container management tool built natively on Apple's Containerization framework. It provides the same Docker CLI commands and flags (`mocker run`, `ps`, `stop`, `build`, `compose`, `stats`) running natively on macOS without Docker Desktop.

- **Open Source:** AGPL-3.0
- **Platform:** macOS (Apple Silicon)
- **Language:** Swift
- **GitHub:** https://github.com/us/mocker