### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [K3S](https://k3s.io/) - The certified Kubernetes distribution built for IoT and Edge computing.
 - [Podman](https://github.com/containers/podman) - A tool for managing OCI containers and pods.
 - [Linx](https://linx.software) - General-purpose low-code platform for building and hosting backend solutions.
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework.
 - [Piku](https://github.com/piku/piku) - The tiniest PaaS you've ever seen. Piku allows you to do git push deployments to your own servers.
 - [OrbStack](https://orbstack.dev/) - fast, light, and easy way to run Docker containers and Linux on MacOS.
 - [Canine](https://canine.sh/) - Deploy applications to Kubernetes as easily as deploying to Heroku


### PR DESCRIPTION
[Mocker](https://github.com/us/mocker) is an open-source (AGPL-3.0), Docker-compatible container CLI for macOS, built natively on Apple's Containerization framework using Swift.

It provides full Docker CLI compatibility, making it a lightweight alternative for macOS users who want native container support without a Linux VM.

Added to the **Applications Platforms** section in alphabetical order.