### PR TITLE
Add Yaw Terminal to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
+- [Yaw](https://yaw.sh) - Cross-platform terminal with built-in SSH client, connection manager, and file editor.
 
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
Add [Yaw](https://yaw.sh) to the Productivity Tools section.

Yaw is a cross-platform terminal with a built-in SSH client, connection manager, and file editor. Available for Windows, macOS, and Linux.