### PR TITLE
Add Delimit to CI/CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Buildkite](https://buildkite.com/) - run fast, secure, and scalable continuous integration pipelines on your own infrastructure.
   - [Cirrus CI](https://cirrus-ci.org/) - continuous integration system built for the era of cloud computing.
   - [Codefresh](https://codefresh.io/) - GitOps automation platform for Kubernetes apps.
+  - [Delimit](https://delimit.ai/) - API governance for CI/CD pipelines. Catches breaking OpenAPI changes before merge.
   - [Github actions](https://github.com/features/actions) - GitHub Actions makes it easy to automate all your software workflows, now with world-class CI/CD.
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.


### PR DESCRIPTION
Adds Delimit under Public Services in the CI/CD section.

Delimit is an API governance tool that plugs into CI pipelines to catch breaking OpenAPI changes before they reach production. It runs as a GitHub Action, analyzes spec diffs, and reports semver-classified results directly on the PR.

Homepage: https://delimit.ai