### PR TITLE
Add CronPeek to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Zabbix](https://www.zabbix.com/) - Mature and effortless monitoring solution for network monitoring and application monitoring.
 - [Glances](https://github.com/nicolargo/glances) - Monitoring information through a curses or Web based interface.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - Cron monitoring tool.
+- [CronPeek](https://cronpeek.web.app) - Dead man's switch monitoring for cron jobs with email and webhook alerts.
 - [Bolo](http://bolo.niftylogic.com/) - Building distributed, scalable monitoring systems.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.


### PR DESCRIPTION
Adds [CronPeek](https://cronpeek.web.app) to the **Observability & Monitoring** section.

CronPeek is a dead man's switch monitoring service for cron jobs. It alerts via email or webhook when expected pings are missed. API-first with a free tier.

- Category: Observability & Monitoring
- Link: https://cronpeek.web.app