### PR TITLE
Add Pipepie to VPN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *VPN, routing and firewall.*
 
 - [OpenVPN](https://openvpn.net/) - Flexible VPN solutions to secure your data communications, whether it's for Internet privacy.
+- [Pipepie](https://github.com/pipepie/pipepie) - Self-hosted encrypted tunnel for exposing localhost with end-to-end Noise NK encryption, webhook inspection, and web dashboard.
 - [Pritunl](https://pritunl.com/) - Enterprise Distributed OpenVPN and IPsec Server.
 - [VyOS](https://vyos.io/) - Open source network OS that runs on a wide range of hardware, virtual machines, and cloud providers.
 - [Algo](https://github.com/trailofbits/algo) - Set up a personal VPN in the cloud.


### PR DESCRIPTION
## Summary
- Add [Pipepie](https://github.com/pipepie/pipepie) to the VPN section
- Pipepie is a self-hosted encrypted tunnel for exposing localhost with end-to-end Noise NK encryption, webhook inspection, AI pipeline tracing, and a web dashboard
- Single Go binary, AGPL-3.0 licensed

## Checklist
- [x] Entry added in alphabetical order
- [x] Entry follows existing format: `- [Name](URL) - Description.`
- [x] Project is open source