### PR TITLE
Add SudoRank to Online Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 ### Online Platforms
 
 - [Cloud Native Playground](https://play.meshery.io) - The Meshery CNCF Playground is an awesome and free resource featuring a live Kubernetes cluster where any CNCF project can be configured and deployed. It is a fantastic interactive learning platform for exploring cloud native technologies.
+- [SudoRank](https://sudorank.com) - Hands-on DevOps challenges on real Linux VMs and Kubernetes clusters covering systemd, Docker, Nginx, networking, and more. Includes structured learning tracks, AI-powered tutoring, and a free tier.
 
 ## Contributing
 


### PR DESCRIPTION
SudoRank is a hands-on DevOps challenge platform where users solve real-world scenarios on actual Linux VMs and Kubernetes clusters (not containers or browser emulations).

**Free tier includes:**
- Access to challenge tracks covering Kubernetes, Docker, Nginx, systemd, networking, and more
- AI-powered tutoring for hints and explanations
- Progress tracking across structured learning paths

The free tier is permanent (not a trial).

**Website:** https://sudorank.com