### PR TITLE
Add DeployHQ CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [AZIN](https://azin.run/) - BYOC deployment platform. Deploy to your own GCP account with git-push, no Kubernetes config needed. GKE Autopilot under the hood.
 - [vCluster](https://vcluster.sh/)- A open source project that helps you create virtual clusters.
 - [devpod](https://devpod.sh/) - Open-source, codebases-like tool that creates reproducible developer environments, supporting numerous providers (Kubernetes, AWS, GCP, etc.).
+- [DeployHQ CLI](https://github.com/deployhq/deployhq-cli) - Command-line interface for the DeployHQ deployment platform. Manage projects, servers, deployments, and releases.
 
 ## Internal Developer Platforms
 


### PR DESCRIPTION
Adds [DeployHQ CLI](https://github.com/deployhq/deployhq-cli) — a Go CLI for the DeployHQ deployment platform.

Features: project/server/deployment management, JSON output with field selection, GitHub Actions integration, CI/CD-friendly auth via env vars.