### PR TITLE
Add Onepilot mobile SSH tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
+- [Onepilot](https://onepilotapp.com) - Mobile SSH and AI agent IDE for iOS. Manage servers and deploy coding agents from your phone.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) to the Productivity Tools section — a mobile SSH and AI agent IDE for iOS.

Similar to `purple` (already listed), but focused on mobile-first server management and AI agent deployment. Placed alongside related SSH tools in the section.