### PR TITLE
Add tailscale-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [SoftEther](https://www.softether.org/) - An Open-Source Free Cross-platform Multi-protocol VPN Program.
 as an academic project from University of Tsukuba, under the Apache License 2.0.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) - MCP server for managing Tailscale tailnets from AI assistants.
 
 ## Resources
 


### PR DESCRIPTION
tailscale-mcp is an open-source MCP server with 52 tools for managing Tailscale tailnets from AI assistants (Claude Code, Cursor, etc.).

Covers devices, ACL/Policy, DNS, auth keys, users, webhooks, audit logs, network lock, and posture integrations.

- **GitHub:** https://github.com/YawLabs/tailscale-mcp
- **npm:** `npx @yawlabs/tailscale-mcp`
- **License:** MIT