### PR TITLE
Add gitty to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 - [tenv](https://github.com/tofuutils/tenv) - streamline IaC version manager for OpenTofu, Terraform, Terragrunt and Atmos, written in Go.
 - [Telert](https://github.com/navig-me/telert) - Get alerts when terminal commands finish via Telegram, Slack, Audio, etc.
+- [gitty](https://github.com/Omibranch/gitty) - Single-binary CLI that shortens the git+GitHub daily workflow. `gitty up` replaces `git add . && git commit && git push`.
 - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management.
 - [tfenv](https://github.com/tfutils/tfenv) - Terraform version manager.
 - [Kanvas](https://kanvas.new) - a collaborative tool with visual interface for designing and operating infrastructure.


### PR DESCRIPTION
## What is gitty?

[gitty](https://github.com/Omibranch/gitty) is a single-binary CLI that shortens the daily git+GitHub workflow.

Core idea: \`gitty up\` replaces \`git add . && git commit -m "..." && git push\`

**Why it belongs in Productivity Tools:**
- Reduces 3-command commit-push cycle to one command
- Zero runtime dependencies, single binary (Linux/macOS/Windows)
- Semantic shortcuts: \`gitty push=main\`, \`gitty pull~dev\`
- Works alongside existing git and gh setups

Available via Homebrew, AUR (Arch), winget (Windows), and install script.