### PR TITLE
add Rollgate to CI/CD feature flag tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [PipeCD](https://pipecd.dev/) - Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications.
   - [Dagger](https://dagger.io/) - CI/CD as Code that Runs Anywhere.
   - [Unleash](https://www.getunleash.io) - Open-source feature management platform (feature flags, gradual rollouts, A/B testing) to decouple deploy from release.
+  - [Rollgate](https://rollgate.io) - Feature flag management with scheduled releases, instant rollback, and A/B testing. 13 SDKs included. Free tier with 500K requests/month.
 - Public Services
   - [Travis CI](https://travis-ci.org/) - easily sync your projects, you’ll be testing your code in minutes.
   - [Circle CI](https://circleci.com/) - powerful CI/CD pipelines that keep code moving.


### PR DESCRIPTION
Adds [Rollgate](https://rollgate.io) to the CI/CD section, next to Unleash.

**Application**: Rollgate
**Category**: CI/CD — Feature flag management
**Link**: https://rollgate.io
**Open source project page**: https://github.com/rollgate/sdks (13 open-source SDKs for Go, Node, Python, Java, .NET, Flutter, React, Vue, Angular, Svelte, React Native, Browser)

Rollgate is a feature flag management platform with scheduled releases, instant rollback, gradual rollouts, user targeting, and A/B testing. Free tier includes 500K API requests/month with all SDKs.