### PR TITLE
Add AgentsMesh to Internal Developer Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Port](https://www.getport.io/) - A platform for building no-code, holistic, Internal Developer Portals.
 - [Backstage](https://backstage.io/) - An open platform for building developer portals.
 - [Kratix](https://kratix.io/) - A framework used by platform teams to build the custom platforms tailored to their organisation.
+- [AgentsMesh](https://agentsmesh.ai) - AI-native developer platform. Provisions remote AI workstations (AgentPods) for autonomous coding agents with PTY sandbox + git worktree isolation, multi-agent collaboration via channels, built-in Kanban, per-pod MCP server, multi-Git provider (GitHub/GitLab/Gitee), multi-tenant (Org > Team > User), SSO/RBAC/audit, BYOK. Self-hostable.
 
 ## Container Image Registry
 


### PR DESCRIPTION
Adding [AgentsMesh](https://agentsmesh.ai) to **Internal Developer Platforms** alongside Port / Backstage / Kratix.

Framing: AgentsMesh is an **AI-native IDP** — like Backstage but users are AI coding agents rather than humans. Provisions remote AI workstations (AgentPods) for autonomous agents, with full platform-engineering primitives:
- **Multi-tenant** — Org > Team > User, row-level isolation
- **SSO / RBAC / audit logs / air-gapped deployment**
- **Multi-Git provider** (GitHub / GitLab / Gitee)
- **Self-service provisioning** — users spin up AgentPods from a web console
- **Per-pod MCP server** — Claude Code / Cursor integration
- **BYOK** — cost control
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode

1.5k+ stars, v0.28.0 (2026-04-15), BSL-1.1 license (transitions to GPL-2.0-or-later on 2030-02-28).