### PR TITLE
Add changegen - Generate changelogs from git history

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 *All the tools, services which increase productivity, developer velocity and developer experience.*
 
+- [changegen](https://github.com/creativengine-ai/changegen) - Generate clean, categorized changelogs from git commit history using Conventional Commits.
 - [tenv](https://github.com/tofuutils/tenv) - streamline IaC version manager for OpenTofu, Terraform, Terragrunt and Atmos, written in Go.
 - [Telert](https://github.com/navig-me/telert) - Get alerts when terminal commands finish via Telegram, Slack, Audio, etc.
 - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management.


### PR DESCRIPTION
Adds [changegen](https://github.com/creativengine-ai/changegen) to the Productivity Tools section.

`changegen` is a CLI tool that generates clean, categorized changelogs from git commit history using [Conventional Commits](https://www.conventionalcommits.org/).

- Run `npx @creativengine-ai/changegen` to generate a `CHANGELOG.md` from git history since last tag
- Automatically categorizes commits by type (feat, fix, chore, etc.)
- Colorized terminal output + writes CHANGELOG.md