### PR TITLE
Add issue-dash to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
+- [issue-dash](https://github.com/GiulioSavini/issue-dash) - Self-hosted GitHub Issues and PR dashboard with AI triage suggestions, CI failure analysis, and unresolved review comment tracking. Docker-ready.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
## What is this?

[issue-dash](https://github.com/GiulioSavini/issue-dash) is a self-hosted GitHub Issues and PR dashboard with:

- Live view of open issues, PRs, CI status, and unresolved review comments
- AI-powered triage suggestions and CI failure root cause analysis (via GitHub Models — free, no Copilot required)
- Auto-refresh every 15 minutes
- Repo switcher at runtime
- Zero dependencies beyond Python 3.12
- Docker-ready (`docker compose up`)

It boosts developer productivity by surfacing what needs attention across a GitHub repo without leaving the terminal/browser.

## Checklist

- [x] The tool is open source
- [x] The link is working
- [x] Added to the correct section (Productivity Tools)
- [x] Entry follows the existing format