### PR TITLE
Add Qovery to Internal Developer Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Port](https://www.getport.io/) - A platform for building no-code, holistic, Internal Developer Portals.
 - [Backstage](https://backstage.io/) - An open platform for building developer portals.
 - [Kratix](https://kratix.io/) - A framework used by platform teams to build the custom platforms tailored to their organisation.
+- [Qovery](https://www.qovery.com/) - Enterprise Kubernetes management platform for deploying applications on AWS, GCP, Azure, and Scaleway. Includes Terraform provider, CLI, API, and an [AI Agent Skill](https://github.com/Qovery/qovery-skills) for deploying from AI coding tools like Claude Code, Cursor, and OpenCode.
 
 ## Container Image Registry
 


### PR DESCRIPTION
Adds [Qovery](https://www.qovery.com) to the Internal Developer Platforms section.

Qovery is an enterprise Kubernetes management platform that provides developer self-service for deploying applications on AWS, GCP, Azure, and Scaleway. It includes:
- Terraform provider for infrastructure as code
- CLI and REST API for automation
- MCP Server for AI-based infrastructure management
- An [AI Agent Skill](https://github.com/Qovery/qovery-skills) that works with Claude Code, Cursor, OpenCode, and 30+ AI coding tools

Website: https://www.qovery.com
GitHub: https://github.com/Qovery