### PR TITLE
Add API Gateway Cost Calculator to API Gateway section

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 *API Gateway, Service Proxy and Service Management tools.*
 
+- [API Gateway Cost Calculator](https://apigatewaycost.com) - Estimate and compare API gateway costs across AWS, Azure, Kong, Tyk, and Apigee.
 - [API Umbrella](https://github.com/NREL/api-umbrella) - Proxy that sits in front of your APIs, API management platform.
 - [Ambassador](https://www.getambassador.io/) - Kubernetes-Native API Gateway built on the Envoy Proxy.
 - [Kong](https://konghq.com/) - Connect all your microservices and APIs with the industry’s most performant, scalable and flexible API platform.


### PR DESCRIPTION
The API Gateway section currently lists only gateway platforms themselves (Kong, Tyk, Ambassador, Envoy). It doesn't include any tooling to help teams compare costs, which is a common decision point when choosing between managed services (AWS API Gateway, Apigee) and self-hosted options (Kong, Tyk).

This calculator provides a structured comparison of per-call and per-million-request pricing across the main API gateway options. It's useful at the architecture stage when a team is deciding which gateway to adopt and needs to model costs at their expected request volume.

Free to use, no account required. Description is 79 characters to stay under the 80-char limit in CONTRIBUTING.md.