### PR TITLE
Add endpulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [endpulse](https://github.com/kimhinton/endpulse) - Multi-endpoint API health CLI with assertions, SSL, and CI exit codes.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
## Application

- **Name:** endpulse
- **Category:** Observability & Monitoring
- **Link:** https://github.com/kimhinton/endpulse
- **License:** MIT
- **Language:** Python 3.9+

Multi-endpoint API health CLI with response assertions (body, regex, headers, status), SSL certificate expiry monitoring, watch mode, webhook alerts (Slack / Discord / generic), and CI exit codes. Zero infrastructure — `pip install endpulse` and run from terminal or CI.

Complements existing entries like [Canary Checker](https://canarychecker.io) (server/platform) and [Healthchecks](https://github.com/healthchecks/healthchecks) (cron monitor) by filling the zero-infra CLI niche for post-deploy and CI health gates.

## Contribution checklist

- [x] Single commit for a single category
- [x] Imperative PR title (`Add endpulse`)
- [x] Entry added to the bottom of the relevant category
- [x] Format: `[NAME](LINK) - DESCRIPTION.` (trailing period, no trailing whitespace)
- [x] Description under 80 characters
- [x] Open source project page linked