### PR TITLE
Add DevOps Mastery Curriculum to DevOps Roadmap resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 
 - [Roadmap.sh DevOps](https://roadmap.sh/devops): Basic understanding and what you should know to become a *DevOps* Engineer.
 - [Dynamic DevOps Roadmap](https://devopsroadmap.io): A Progressive, Non-Linear, and T-Shaped roadmap that works as a master plan to kickstart your DevOps Engineer career in the Cloud Native era following the Agile MVP style.
+- [DevOps Mastery Curriculum](https://github.com/Kuldeep2822k/devops-mastery-curriculum): A production-grade, local-first DevOps curriculum to go from zero to staff engineer. 25 modules covering Linux, Kubernetes, CI/CD, IaC, Ansible, SRE, Observability, Security, and Platform Engineering — with labs, runbooks, ADRs, and time-boxed incident drills.
 
 ### Online Platforms
 


### PR DESCRIPTION
## What this adds

[DevOps Mastery Curriculum](https://github.com/Kuldeep2822k/devops-mastery-curriculum) — a production-grade, local-first DevOps curriculum to go from zero to staff engineer.

**Why it belongs here:**
- 25 structured modules covering Linux, Kubernetes, CI/CD, Terraform, Ansible, SRE, Observability, Security, and Platform Engineering
- Evidence-based completion: labs with verify signals, runbooks, ADRs, 0–4 rubric scoring per skill
- Local-first: core labs run without a cloud account (Docker, kind/minikube, OpenTofu)
- Time-boxed incident drills and troubleshooting-labs in every module
- Covers 4 learning schedules: 30-day boot, 90-day deep, 180-day staff, 365-day mastery

Added to the **DevOps Roadmap** section as a curriculum-style resource alongside existing roadmaps.