### PR TITLE
feat: add KubeStellar Console to Internal Developer Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Port](https://www.getport.io/) - A platform for building no-code, holistic, Internal Developer Portals.
 - [Backstage](https://backstage.io/) - An open platform for building developer portals.
 - [Kratix](https://kratix.io/) - A framework used by platform teams to build the custom platforms tailored to their organisation.
+- [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with real-time observability across edge and cloud clusters. CNCF Sandbox project.
 
 ## Container Image Registry
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Internal Developer Platforms** section.

KubeStellar Console is an open source AI-powered multi-cluster Kubernetes dashboard serving as a developer platform for teams operating multiple Kubernetes environments (edge and cloud). It is a CNCF Sandbox project with 20+ CNCF integrations including Argo CD, Prometheus, Grafana, and more.

- GitHub: https://github.com/kubestellar/console
- Live demo: https://console.kubestellar.io