### PR TITLE
Add arn-infra to Automation & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Terrateam](https://terrateam.io) - Open-source alternative to Terraform Cloud/Enterprise, GitOps-first with native GitHub integration and designed for scale, security, and reliability.
 - [Scalr](https://scalr.com/) - Drop-in Terraform Cloud alternative, usage-based pricing, unlimited concurrency.
 - [CloudRay](https://cloudray.io) - Centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.
+- [arn-infra](https://github.com/AppsVortex/arness/tree/main/plugins/arn-infra) - Claude Code plugin for Terraform, Kubernetes, and AWS infrastructure.
 
 ## Productivity Tools
 


### PR DESCRIPTION
Submitting arn-infra for the Automation & Orchestration section. It's a Claude Code plugin (MIT-licensed) that runs Terraform/OpenTofu generation, Kubernetes manifest authoring, CI/CD pipeline scaffolding, and structured change management inside an existing Claude Code session.

Closest neighbors in the section are Atlantis, Digger, and Terrateam. Those run as CI/CD automations or as separate platforms. arn-infra is different in shape: it runs as a plugin at AI-dev-time, producing IaC files, runbooks, and phased rollback plans as structured Markdown/JSON artifacts the developer reviews and commits to their own repo. There is no server, no webhook receiver, and no hosted control plane.

Install:

`/plugin marketplace add AppsVortex/arness`
`/plugin install arn-infra@arn-marketplace`

Capabilities: Dockerfile generation, OpenTofu/Terraform IaC, environment management, secrets, Checkov/Trivy security audit, Infracost cost analysis, and provider migration. License: MIT.