### PR TITLE
Add nylas under Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
+- [nylas](https://github.com/nylas/cli) - Email, calendar, and contacts CLI for terminal and CI/CD. One auth covers Gmail/Outlook/Exchange/Yahoo/iCloud/IMAP, JSON output for scripting, built-in MCP server. Docs at https://cli.nylas.com.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds nylas to the Productivity Tools section.

**What it is:** Email, calendar, and contacts CLI built in Go. One auth flow covers Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP. JSON output for scripting, built-in MCP server for AI agents.

**Why Productivity Tools:** Useful primitive for DevOps workflows — sending alerts/notifications, automating mail-driven workflows from CI, or wiring email into Slack/Telegram bridges.

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com
**Install:** `brew install nylas/nylas-cli/nylas`