### PR TITLE
Add mirrord to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
+- [mirrord](https://metalbear.com/mirrord/) - Run a local process as if it were a pod in a remote Kubernetes cluster.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
## Add mirrord

mirrord lets developers run local services as if they were inside a remote Kubernetes cluster, with no deploys and no mocking. Improves developer velocity for cloud-native applications.

- Open source under MIT
- Repo: https://github.com/metalbear-co/mirrord (5,059 stars, 57 contributors)
- Site: https://metalbear.com/mirrord/
- Docs: https://metalbear.com/mirrord/docs

Category: Productivity Tools (alongside kubefwd, which sits in the same local-Kubernetes-development category).