### PR TITLE
Add DevHelm to Observability & Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.
 - [Co-Pilot](https://pcp.io/) - System performance analysis toolkit.
+- [DevHelm](https://devhelm.io) - Developer-first uptime monitoring with multi-protocol checks, dependency intelligence, status pages, and config-as-code.
 - [Keep](https://github.com/keephq/keep) - Open source alerting CLI for developers.
 - [Globalping CLI](https://github.com/jsdelivr/globalping-cli) - Run network commands like ping, traceroute and mtr from hundreds of global locations.
 - [Grai](https://github.com/grai-io/grai-core) - Open source observability integrating data impact analysis into CI.


### PR DESCRIPTION
Adds [DevHelm](https://devhelm.io) to the **Observability & Monitoring** section.

DevHelm is a developer-first uptime monitoring platform with multi-protocol checks (HTTP, DNS, TCP, ICMP, heartbeat), dependency intelligence for 80+ providers, hosted status pages, and config-as-code support.

Full developer surface: CLI (`devhelm` on npm), Python SDK, JS/TS SDK, Terraform provider, and MCP server.

Docs: https://docs.devhelm.io  
GitHub: https://github.com/devhelmhq

Actively maintained with weekly releases.