### PR TITLE
Add AgentTier to Internal Developer Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Port](https://www.getport.io/) - A platform for building no-code, holistic, Internal Developer Portals.
 - [Backstage](https://backstage.io/) - An open platform for building developer portals.
 - [Kratix](https://kratix.io/) - A framework used by platform teams to build the custom platforms tailored to their organisation.
+- [AgentTier](https://github.com/agenttier/agenttier) - Kubernetes-native sandboxes for developers and AI agents from a single CRD.
 
 ## Container Image Registry
 


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) to the **Internal Developer Platforms** section.

**Application:** AgentTier
**Category:** Internal Developer Platforms
**Open source project:** https://github.com/agenttier/agenttier (Apache-2.0)

AgentTier is a Kubernetes-native platform that provisions isolated, persistent sandboxes for both human developers and AI coding agents from a single `Sandbox` CRD. Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation. Sandboxes can run interactively (browser terminal) or as headless agent workloads via a streaming REST API. Distributed as a single Helm chart with a Python SDK, Go CLI, and React Web UI.

**Compliance with CONTRIBUTING.md:**

- ✅ Format `[RESOURCE](LINK) - DESCRIPTION.` with description under 80 characters and ending in a full stop.
- ✅ Single commit, single category.
- ✅ Imperative PR title.
- ✅ No duplicate entry — checked.
- ✅ No trailing whitespace.

The diff is a single-line addition at the bottom of the existing IDP list.
