### PR TITLE
Add SigCLI to Secret Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Git Secret](https://github.com/sobolevn/git-secret) - A bash-tool to store your private data inside a git repository.
 - [Infisical](https://github.com/Infisical/infisical) - Open source end-to-end encrypted secrets sync for teams and infrastructure.
 - [Lade](https://github.com/zifeo/lade) - Automatically load secrets from your preferred vault as environment variables.
+- [SigCLI](https://github.com/sigcli/sigcli) - Authenticate via browser or OAuth2 once, then provide fresh credentials to any CLI tool or AI agent.
 
 ## Security
 


### PR DESCRIPTION
Adding [SigCLI](https://github.com/sigcli/sigcli) to the Secret Management section.

SigCLI handles browser-based and OAuth2 authentication for CLI tools and AI agents. It logs in once via a real browser session (SSO, QR code, OAuth2 Client Credentials), encrypts credentials at rest (AES-256-GCM), and serves fresh tokens/cookies on demand to other tools via `sig get`, `sig run`, or a local MITM proxy.

It complements tools like Vault and Infisical — those manage server-side secrets, while SigCLI manages interactive credentials (browser sessions, OAuth2 tokens) that can't be pre-provisioned.

Particularly important for AI/LLM agent workflows: sigcli's proxy mode ensures credentials never enter the LLM context window. The agent simply calls `sig request <url>` or routes through `sig proxy`. the credential injection happens out-of-band, so tokens are never exposed to logs, training data, or other tools in the conversation. 

**Demo:**
<img width="1280" height="720" alt="demo-v2" src="https://github.com/user-attachments/assets/26aa9a78-9e29-489d-93a0-0c5c6156114a" />

GitHub: https://github.com/sigcli/sigcli