### PR TITLE
Add OpenChoreo to Internal Developer Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Backstage](https://backstage.io/) - An open platform for building developer portals.
 - [Kratix](https://kratix.io/) - A framework used by platform teams to build the custom platforms tailored to their organisation.
 - [Qovery](https://www.qovery.com/) - Enterprise Kubernetes management platform for deploying applications on AWS, GCP, Azure, and Scaleway. Includes Terraform provider, CLI, API, and an [AI Agent Skill](https://github.com/Qovery/qovery-skills) for deploying from AI coding tools like Claude Code, Cursor, and OpenCode.
+- [OpenChoreo](https://openchoreo.dev/) - A complete, modular, open-source developer platform.
 
 ## Container Image Registry
 


### PR DESCRIPTION
Adds OpenChoreo(https://openchoreo.dev/) to the Internal Developer Platforms list.

OpenChoreo is a developer platform for Kubernetes offering development and architecture abstractions, a Backstage-powered developer portal, application CI/CD, GitOps, and observability. It is also a [CNCF (Cloud Native Computing Foundation)](https://www.cncf.io/) sandbox project.

GitHub: https://github.com/openchoreo/openchoreo
Docs: https://openchoreo.dev/docs/