### PR TITLE
add CodeFever Community to Source Code Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Gitblit](https://github.com/gitblit/gitblit) - Pure Java Git solution for managing, viewing, and serving Git repositories.
 - [RhodeCode](https://rhodecode.com/) - Centralized control for distributed repositories. Mercurial, Git, and Subversion under a single roof.
 - [Radicle](https://radicle.xyz/) - Radicle is a sovereign peer-to-peer network for code collaboration, built on top of Git.
+- [CodeFever Community](https://github.com/PGYER/codefever) - Free, MIT-licensed self-hosted Git service by PGYER.
 
 ## Web Servers
 


### PR DESCRIPTION
## Addition

- **Application:** CodeFever Community
- **Category:** Source Code Management
- **Project page:** https://github.com/PGYER/codefever

## About

CodeFever Community is a free, MIT-licensed, self-hosted Git code hosting service built and maintained by [PGYER](https://github.com/PGYER), a developer-tools company operating since 2014 (12+ years), best known as China's leading mobile-app beta-distribution platform. ~2.8k stars, written in PHP with Docker support, with features comparable to Gitea / Forgejo / Gogs (repository management, branch protection, code review, team collaboration, one-line install).

Slotted into the existing **Source Code Management** section alongside Gitea, Gogs, Gitblit, and others. Description is short (<80 chars) and ends with a full stop per CONTRIBUTING.md.