### PR TITLE
Add pingbot to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Zabbix](https://www.zabbix.com/) - Mature and effortless monitoring solution for network monitoring and application monitoring.
 - [Glances](https://github.com/nicolargo/glances) - Monitoring information through a curses or Web based interface.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - Cron monitoring tool.
+- [pingbot](https://github.com/shyh26/pingbot) - Self-hosted cron job monitor with Telegram alerts. One curl command per job.
 - [Bolo](http://bolo.niftylogic.com/) - Building distributed, scalable monitoring systems.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.


### PR DESCRIPTION
pingbot is a self-hosted cron job monitor with Telegram alerts. Single Python process (FastAPI + SQLite), zero external dependencies. MIT licensed.

- One curl command per cron job
- Telegram alerts on LATE/DEAD/RECOVERED transitions
- CLI for managing jobs

GitHub: https://github.com/shyh26/pingbot