### PR TITLE
Add RedirHub to Observability & Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Monit](https://mmonit.com/monit/#home) - Managing and monitoring Unix systems.
 - [Naemon](http://www.naemon.org/) - Fast, stable and innovative while giving you a clear view of the state of your network and applications.
 - [Nagios](https://www.nagios.org/) - Computer-software application that monitors systems, networks and infrastructure.
+- [RedirHub](https://redirhub.com) - URL redirect infrastructure with proactive link monitoring, real-time analytics, and edge network for redirect management.
 - [Sentry](https://sentry.io/welcome/) - Error monitoring that helps all software teams discover, triage, and prioritize errors in real-time.
 - [Shinken](https://github.com/shinken-solutions/shinken) - Monitoring framework.
 - [Zabbix](https://www.zabbix.com/) - Mature and effortless monitoring solution for network monitoring and application monitoring.


### PR DESCRIPTION
Add RedirHub to Observability &amp; Monitoring section. RedirHub is a URL redirect management platform with proactive link monitoring, edge network, REST API, and custom nameservers for DevOps teams.