### PR TITLE
Add platform-skills — open-source AI field handbook for DevOps and platform engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
+- [platform-skills](https://github.com/nitinjain999/platform-skills) - Open-source field handbook for platform, DevOps, SRE, and cloud engineers covering Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and 30+ domains. Works as a Claude, Codex, Cursor, and Copilot plugin with blast radius, validation steps, and rollback plans built in.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
## Description

Adds [platform-skills](https://github.com/nitinjain999/platform-skills) to the Productivity Tools section.

platform-skills is a free, open-source field handbook for platform, DevOps, SRE, and cloud engineers covering Kubernetes, Flux CD, Terraform, GitHub Actions, AWS, OPA/Rego, KEDA, supply chain security, and 30+ more domains. It works as a Claude, Codex, Cursor, and Copilot plugin — giving engineers interactive guidance with blast radius analysis, validation commands, and rollback plans built in.

## Checklist

- [x] Entry added to the Productivity Tools section
- [x] Description is concise and accurate
- [x] Link points to the correct GitHub repo