### PR TITLE
Add net-benchmark to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Co-Pilot](https://pcp.io/) - System performance analysis toolkit.
 - [Keep](https://github.com/keephq/keep) - Open source alerting CLI for developers.
 - [Globalping CLI](https://github.com/jsdelivr/globalping-cli) - Run network commands like ping, traceroute and mtr from hundreds of global locations.
+- [net-benchmark](https://github.com/net-benchmark/net-benchmark) - DNS/HTTP/SSL benchmarking CLI with DNSSEC, DoH/DoT, TLS timing, and resolver performance analysis.
 - [Grai](https://github.com/grai-io/grai-core) - Open source observability integrating data impact analysis into CI.
 - [Canary Checker](https://canarychecker.io) - Open source health check platform.
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.


### PR DESCRIPTION
Add net-benchmark to the Observability & Monitoring section.

net-benchmark is a DNS/HTTP/SSL benchmarking CLI providing resolver performance metrics, DNSSEC validation, DoH/DoT checks, TLS timing, and detailed network analysis. MIT licensed and actively maintained.