### PR TITLE
Add DeployLens to Observability, Monitoring, Metrics/Metrics collection and Alerting tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.
   - [GitLab Pipelines by puzl.cloud](https://puzl.cloud/products/run-my-job/) - Blazing-fast, cost-effective execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
-  - [DeployLens](https://www.deploylens.dev/) - Real-time Kanban dashboard for GitHub deployment pipelines that turns PRs, workflow runs, and environments into a live kanban dashboard via webhooks with zero configuration.
 
 ## Source Code Management
 
@@ -305,6 +304,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 *Observability, Monitoring, Metrics/Metrics collection and Alerting tools.*
 
+- [DeployLens](https://www.deploylens.dev/) - Real-time Kanban dashboard for GitHub deployment pipelines that turns PRs, workflow runs, and environments into a live kanban dashboard via webhooks with zero configuration.
 - [Steampipe](https://steampipe.io/) - The universal SQL interface for any cloud API, & cloud intelligence dashboards extensible w/ HCL+SQL.
 - [Sensu](https://sensu.io/) - Simple. Scalable. Multi-cloud monitoring.
 - [Alerta](https://github.com/alerta/alerta) - Scalable, minimal configuration and visualization monitoring system.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.
   - [GitLab Pipelines by puzl.cloud](https://puzl.cloud/products/run-my-job/) - Blazing-fast, cost-effective execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
+  - [DeployLens](https://www.deploylens.dev/) - Real-time Kanban dashboard for GitHub deployment pipelines that turns PRs, workflow runs, and environments into a live kanban dashboard via webhooks with zero configuration.
 
 ## Source Code Management
 


### PR DESCRIPTION
Adds DeployLens to the Observability, Monitoring, Metrics/Metrics collection and Alerting tools. section.

DeployLens is a real-time Kanban pipeline dashboard for GitHub teams that provides an instant visual map of active workflows, pull requests, and environments. It connects natively via a GitHub App with zero custom YAML or configuration required. It includes:

-  _Live Kanban Board_ – Live visual mapping of workflow states, open PRs, check statuses, and environments driven by GitHub webhooks.
-  _Zero-Config Setup_ – No repository pipeline modifications or custom code files required; registers instantly via the GitHub Marketplace.
- _Standard Mode (Recommended)_ – Uses restricted, read-only permissions (including Contents) solely to enrich your dashboard with change scope labels and recent commit details. No source code is ever stored.
- _Privacy Mode (SOC2-Friendly)_ – Completely strips away the Contents permission, along with Push and Commit comment event subscriptions. Operates entirely on pipeline metadata with zero source code access.

Website: [deploylens.dev](https://www.deploylens.dev/)

**_Just to be fully transparent with the maintainers—I'm actually one of the builders of DeployLens! I wanted to share it here because I genuinely think it fills a big visibility gap for the community, but wanted to make sure I disclosed that relationship upfront._**