### PR TITLE
Add ZopNight to Automation & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [RapidForge.io](https://rapidforge.io/) - Create end points, forms and tasks using scripts. Automate your workflows.
 - [Terrateam](https://terrateam.io) - Open-source alternative to Terraform Cloud/Enterprise, GitOps-first with native GitHub integration and designed for scale, security, and reliability.
 - [Scalr](https://scalr.com/) - Drop-in Terraform Cloud alternative, usage-based pricing, unlimited concurrency.
+- [ZopNight](https://github.com/zopdev/zopnight) - Multi-cloud FinOps autopilot that schedules and optimizes idle cloud resources.
 - [CloudRay](https://cloudray.io) - Centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.
 
 ## Productivity Tools

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [RapidForge.io](https://rapidforge.io/) - Create end points, forms and tasks using scripts. Automate your workflows.
 - [Terrateam](https://terrateam.io) - Open-source alternative to Terraform Cloud/Enterprise, GitOps-first with native GitHub integration and designed for scale, security, and reliability.
 - [Scalr](https://scalr.com/) - Drop-in Terraform Cloud alternative, usage-based pricing, unlimited concurrency.
+- [Zopnight](https://zop.dev/zopnight?utm_source=wmariuss-awesome-devops&utm_medium=listing&utm_campaign=mcp-directory) - Multi-cloud cost governance with resource scheduling and rightsizing.
 - [CloudRay](https://cloudray.io) - Centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.
 
 ## Productivity Tools


### PR DESCRIPTION
Adds **Zopnight** to the Automation & Orchestration section.

Zopnight is a cloud cost and infrastructure governance platform for AWS, Azure and GCP: cost allocation by provider, resource, tag and team, budgets and spend tracking, rightsizing and idle-resource recommendations, and resource scheduling. It also ships a first-party remote MCP server, so the same data can be queried from an AI assistant.

The description in the list itself is kept under 80 characters and ends with a full stop, per the contributing guide. The link points to the product page.

**Links**

- server link - https://api.zop.dev/mcp-server
- learn doc - https://zop.dev/learn/mcp-server
- claude learn - https://zop.dev/learn/how-to/set-up-zopnight-mcp-for-claude

Disclosure: I work on Zopnight.