### PR TITLE
Add Faultline

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
+- [Faultline](https://github.com/faultline-cli/faultline) - Classifies CI build logs into failure types with evidence and fix steps.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds Faultline, an open-source deterministic CI failure analysis CLI.

Faultline classifies build logs into explainable failure types with supporting evidence and fix steps. It is designed for repeatable CI/CD debugging workflows where stable output is useful for developers, maintainers, and automation.

Repo: https://github.com/faultline-cli/faultline
