### PR TITLE
Add rustunnel to VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [SoftEther](https://www.softether.org/) - An Open-Source Free Cross-platform Multi-protocol VPN Program.
 as an academic project from University of Tsukuba, under the Apache License 2.0.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [rustunnel](https://github.com/joaoh82/rustunnel) - Open-source self-hosted secure tunnel server written in Rust. Supports HTTP/HTTPS/TCP/UDP, TLS, and Prometheus metrics.
 
 ## Resources
 


### PR DESCRIPTION
Hi! I'm Joao (@joaoh82), author of rustunnel — an open-source secure tunnel server in Rust (https://rustunnel.com).

DevOps angle: rustunnel is the kind of tool people reach for when they need to test webhooks against local code, expose a dev server to a designer/teammate, or hand a CI run something it can reach from outside the cluster. It's self-hostable on a single VPS (systemd / Docker / Docker Compose templates included) or runnable on our pay-as-you-go managed multi-region service.

- Source: https://github.com/joaoh82/rustunnel
- Docs: https://rustunnel.com/docs
- License: AGPL-3.0

Inserted under **VPN**. Happy to adjust description, section placement, or formatting if anything's off.