### PR TITLE
Add Fortem — ECS Fargate fleet control plane to IDP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Port](https://www.getport.io/) - A platform for building no-code, holistic, Internal Developer Portals.
 - [Backstage](https://backstage.io/) - An open platform for building developer portals.
 - [Kratix](https://kratix.io/) - A framework used by platform teams to build the custom platforms tailored to their organisation.
+- [Fortem](https://fortem.dev) - ECS Fargate fleet control plane for platform engineers. Per-environment scheduling, fleet-wide visibility, developer self-service, environment templates.
 - [Qovery](https://www.qovery.com/) - Enterprise Kubernetes management platform for deploying applications on AWS, GCP, Azure, and Scaleway. Includes Terraform provider, CLI, API, and an [AI Agent Skill](https://github.com/Qovery/qovery-skills) for deploying from AI coding tools like Claude Code, Cursor, and OpenCode.
 
 ## Container Image Registry


### PR DESCRIPTION
Add [Fortem](https://fortem.dev) to Internal Developer Platforms.

Fortem is a control plane for teams running 10+ ECS Fargate environments. It adds the operational layer missing from ECS: per-environment scheduling (60-70% cost reduction on dev/staging), fleet-wide visibility, developer self-service with RBAC, environment templates, and AI diagnostics.

- Website: https://fortem.dev
- Demo: https://demo.fortem.dev
- Free Fleet Audit: https://fortem.dev/audit