### PR TITLE
Add Pipewright to Continuous Integration & Delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [PipeCD](https://pipecd.dev/) - Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications.
   - [Dagger](https://dagger.io/) - CI/CD as Code that Runs Anywhere.
   - [Unleash](https://www.getunleash.io) - Open-source feature management platform (feature flags, gradual rollouts, A/B testing) to decouple deploy from release.
+  - [Pipewright](https://github.com/huangchengsir/pipewright) - self-hosted CI/CD, deployment and ops platform in a single binary.
 - Public Services
   - [Travis CI](https://travis-ci.org/) - easily sync your projects, you’ll be testing your code in minutes.
   - [Circle CI](https://circleci.com/) - powerful CI/CD pipelines that keep code moving.


### PR DESCRIPTION
**Application name:** Pipewright

**Category:** Continuous Integration & Delivery → On-premises

**Project page:** https://github.com/huangchengsir/pipewright

Pipewright is a self-hosted, open-source (MIT) CI/CD, deployment and ops platform shipped as a single Go binary, with visual DAG pipelines, agentless deployment over SSH, container management and a web terminal. Latest release: v1.2.2 (binaries + ghcr.io container images).

Entry follows the `[RESOURCE](LINK) - DESCRIPTION.` format with a description under 80 characters ending with a full stop.