### PR TITLE
add Domain Expiry Monitor GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Zabbix](https://www.zabbix.com/) - Mature and effortless monitoring solution for network monitoring and application monitoring.
 - [Glances](https://github.com/nicolargo/glances) - Monitoring information through a curses or Web based interface.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - Cron monitoring tool.
+- [Domain Expiry Monitor](https://github.com/iPythoning/domain-expiry-action) - GitHub Action to monitor domain WHOIS expiry dates and send alerts.
 - [Bolo](http://bolo.niftylogic.com/) - Building distributed, scalable monitoring systems.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Awesome DevOps
 
+<!-- bmc:front -->
+<p align="center"><a href="https://buymeacoffee.com/dayongfan"><img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&amp;emoji=&amp;slug=dayongfan&amp;button_colour=FFDD00&amp;font_colour=000000&amp;font_family=Cookie&amp;outline_colour=000000&amp;coffee_colour=ffffff" alt="Buy me a coffee"></a></p>
+<!-- /bmc:front -->
+
 [![Awesome DevOps](http://awesome-devops.xyz/assets/banner.png)](https://github.com/wmariuss/awesome-devops)
 
 [![Deploy](https://github.com/wmariuss/awesome-devops/actions/workflows/deploy.yml/badge.svg)](https://github.com/wmariuss/awesome-devops/actions/workflows/deploy.yml)
@@ -257,6 +261,10 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Gitblit](https://github.com/gitblit/gitblit) - Pure Java Git solution for managing, viewing, and serving Git repositories.
 - [RhodeCode](https://rhodecode.com/) - Centralized control for distributed repositories. Mercurial, Git, and Subversion under a single roof.
 - [Radicle](https://radicle.xyz/) - Radicle is a sovereign peer-to-peer network for code collaboration, built on top of Git.
+
+<!-- bmc:middle -->
+<p align="center"><a href="https://buymeacoffee.com/dayongfan"><img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&amp;emoji=&amp;slug=dayongfan&amp;button_colour=FFDD00&amp;font_colour=000000&amp;font_family=Cookie&amp;outline_colour=000000&amp;coffee_colour=ffffff" alt="Buy me a coffee"></a></p>
+<!-- /bmc:middle -->
 
 ## Web Servers
 
@@ -526,6 +534,6 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 
 Your contributions are always welcome! Please take a look at the [Contribution Guidelines](https://github.com/wmariuss/awesome-devops/blob/main/docs/contribution.md).
 
-## Support
-
-[![Buy me a coffee](https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&emoji=&slug=dayongfan&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff)](https://buymeacoffee.com/dayongfan)
+<!-- bmc:end -->
+<p align="center"><a href="https://buymeacoffee.com/dayongfan"><img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&amp;emoji=&amp;slug=dayongfan&amp;button_colour=FFDD00&amp;font_colour=000000&amp;font_family=Cookie&amp;outline_colour=000000&amp;coffee_colour=ffffff" alt="Buy me a coffee"></a></p>
+<!-- /bmc:end -->

--- a/README.md
+++ b/README.md
@@ -525,3 +525,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 ## Contributing
 
 Your contributions are always welcome! Please take a look at the [Contribution Guidelines](https://github.com/wmariuss/awesome-devops/blob/main/docs/contribution.md).
+
+## Support
+
+[![Buy me a coffee](https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&emoji=&slug=dayongfan&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff)](https://buymeacoffee.com/dayongfan)


### PR DESCRIPTION
## Description

Add [Domain Expiry Monitor](https://github.com/iPythoning/domain-expiry-action) to the Observability & Monitoring section.

A free, open-source GitHub Action that monitors domain WHOIS expiry dates and sends alerts via Slack, Email, or GitHub Issues. Supports batch domain checking, configurable alert thresholds, and TLD-specific WHOIS parsing.

- **Repository**: https://github.com/iPythoning/domain-expiry-action
- **Marketplace**: https://github.com/marketplace/actions/domain-expiry-monitor
- **License**: MIT