### PR TITLE
Add DOS commit-audit gate to Code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [MeshMap](https://layer5.io/cloud-native-management/meshmap) - World’s only visual designer for Kubernetes and cloud native applications. Design, deploy, and manage your Kubernetes-based, cloud native deployments allowing you to speed up infrastructure configuration.
 - [Potpie](https://potpie.ai) - AI agent that understands your code changes and computes the blast radius of your changes. 
 - [CodeRabbit](https://coderabbit.ai) - AI-powered code review tool that integrates with GitHub. It automates routine checks, provides intelligent feedback, and helps maintain consistent code quality.
+- [DOS](https://github.com/anthony-chaudhary/dos-kernel) - Commit-audit gate for AI-assisted development: fails a build when a commit message claims work its own diff does not contain. CLI plus a GitHub Action and GitLab CI template.
 
 ## Distributed Messaging
 


### PR DESCRIPTION
Adds DOS Kernel — https://github.com/anthony-chaudhary/dos-kernel — to the **Code review** section.

DOS is a deterministic trust kernel for AI coding agents and agent fleets. It computes verdicts from evidence the agent didn't author: `dos verify` checks that a claimed unit of work actually landed (git ancestry, not self-report), `dos arbitrate` decides whether two concurrent agents may touch the same files, and `dos commit-audit` flags a commit whose message claims work its own diff doesn't contain. MIT-licensed, Python (PyPI: `dos-kernel`), ships an MCP server (`dos-mcp`) and hooks for Claude Code, Cursor, Codex, Gemini CLI, Antigravity, and Claude Cowork.

Placement follows the list's contribution guidelines; link verified.