### PR TITLE
Update RunMyJob entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Github actions](https://github.com/features/actions) - GitHub Actions makes it easy to automate all your software workflows, now with world-class CI/CD.
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.
-  - [GitLab Pipelines by puzl.cloud](https://puzl.cloud/products/run-my-job/) - Blazing-fast, cost-effective execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
+  - [RunMyJob](https://runmyjob.io/) - Cloud runners for GitHub Actions and GitLab CI with KVM-isolated VMs and load-based billing.
 
 ## Source Code Management
 


### PR DESCRIPTION
Updates the existing Puzl CI runner entry to the current RunMyJob name and product URL.

The entry already points to the RunMyJob product page, but the visible name and description still refer to the older GitLab Pipelines wording. This keeps the same list placement while making the entry current and noting GitHub Actions support as well.
