### PR TITLE
add DeployHQ to Continuous Integration & Delivery / Public Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Buildkite](https://buildkite.com/) - run fast, secure, and scalable continuous integration pipelines on your own infrastructure.
   - [Cirrus CI](https://cirrus-ci.org/) - continuous integration system built for the era of cloud computing.
   - [Codefresh](https://codefresh.io/) - GitOps automation platform for Kubernetes apps.
+  - [DeployHQ](https://www.deployhq.com/) - Git-based deployment automation to servers via SSH/SFTP/S3.
   - [Github actions](https://github.com/features/actions) - GitHub Actions makes it easy to automate all your software workflows, now with world-class CI/CD.
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.


### PR DESCRIPTION
Adds [DeployHQ](https://www.deployhq.com/) to `## Continuous Integration & Delivery → Public Services`.

DeployHQ is a hosted Git-based deployment service (founded 2009) that deploys from GitHub, GitLab, and Bitbucket to servers via SSH, SFTP, and S3, with build pipelines, zero-downtime deploys, and one-click rollback. A free tier is available (1 project, 10 deploys/day, 30 build minutes/month).

Entry follows the CONTRIBUTING.md format: `[RESOURCE](LINK) - DESCRIPTION.` (76 chars, under the 80-char cap, ends in full stop). Slotted alphabetically between Codefresh and Github actions in the Public Services group.

- Project page: https://www.deployhq.com/
- Category: Continuous Integration & Delivery → Public Services