### PR TITLE
Add Prismix to Status monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Cachet](https://github.com/CachetHQ/Cachet) - Beautiful and powerful open-source status page system.
   - [StatusPal](https://statuspal.io/?utm_source=github.com&utm_medium=referral&utm_campaign=awesome-devops) - Communicate incidents and maintenance effectively with a beautiful hosted status page.
   - [Instatus](https://instatus.com) - Quick and beautiful status page.
+  - [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini). Free REST API at /api/v1/statuses.
 
 ## Service Discovery & Service Mesh
 


### PR DESCRIPTION
Adds [Prismix](https://prismix.dev) to the **Status** subsection under Observability & Monitoring.

**What it is:** Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Google Gemini, Cursor, Groq, and more). Includes a free REST API at `/api/v1/statuses` for programmatic status checks.

**Why it fits this list:** Prismix is an AI-service status hub — the DevOps/SRE equivalent of uptime monitoring but specifically for LLM/AI APIs that dev teams depend on. Fits alongside Cachet, StatusPal, and Instatus.

- Free, no auth required to use
- REST API with 60s cache, returns JSON status for all providers
- Email + webhook alerts for starred services (Pro tier)
- Live: https://prismix.dev