### PR TITLE
Add Cynative to security tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC with API for CI/CD integration.
-- [Cynative](https://github.com/cynative/cynative): Open-source deep security research for AWS, GCP, Azure, K8s, GitHub and GitLab. Read-only by construction.
+- [Cynative](https://github.com/cynative/cynative): Open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).
 
 ## Sharing
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC with API for CI/CD integration.
+- [Cynative](https://github.com/cynative/cynative): Agentic security CLI that runs code in a built-in sandbox to research AWS, GCP, Azure, Kubernetes, GitHub and GitLab. Read-only enforced by default.
 
 ## Sharing
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC with API for CI/CD integration.
-- [Cynative](https://github.com/cynative/cynative): Agentic security CLI that runs code in a built-in sandbox to research AWS, GCP, Azure, Kubernetes, GitHub and GitLab. Read-only enforced by default.
+- [Cynative](https://github.com/cynative/cynative): Open-source deep security research for AWS, GCP, Azure, K8s, GitHub and GitLab. Read-only by construction.
 
 ## Sharing
 


### PR DESCRIPTION
Added Cynative: Open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).