### PR TITLE
add Vigil - open source uptime monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [Vigil](https://github.com/isak-ialogics/vigil) - Multi-region uptime monitoring with SSL alerts, heartbeats, broken-link detection, and public status pages.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
## Addition

Adds [Vigil](https://github.com/isak-ialogics/vigil) to the **Observability & Monitoring** section.

**Vigil** is an open source, self-hostable uptime monitoring platform built on Laravel/PHP with Docker support. It provides:
- Multi-region HTTP/API uptime checks with false-positive elimination via probe consensus
- SSL certificate expiry alerts
- Heartbeat monitoring (dead-man's switch for cron jobs)
- Broken-link detection
- Response time history charts
- Public status pages
- Alert channels: Email, Slack, webhooks

- Source: https://github.com/isak-ialogics/vigil
- Demo: https://app.vigilmon.online
- License: MIT

Follows the contribution format: `[RESOURCE](LINK) - DESCRIPTION.` with description under 80 characters.