### PR TITLE
Add InterServer to Public and Private Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Scaleway](https://www.scaleway.com/) - Single way to create, deploy and scale your infrastructure in the cloud.
 - [Vultr](https://www.vultr.com/) - Easily deploy cloud servers, bare metal, and storage worldwide.
 - [IBM Cloud](https://www.ibm.com/cloud) - Tools, data & APIs to make AI real now.
+- [Interserver](https://www.interserver.net/) - Cloud VPS, Linux VPS, Windows VPS, dedicated servers and web hosting services.
 - [Linode](https://linode.com/) - Accelerate innovation in the cloud, virtual computing must be more accessible, affordable, and simple.
 - [Kinsta](https://kinsta.com/application-hosting/) - Create and deploy web applications and databases in minutes.
 - [Equinix](https://www.equinix.com/) - Global data center and colocation provider for enterprise network and cloud computing.


### PR DESCRIPTION
This PR adds InterServer to the Public and Private Cloud Platforms section.

InterServer provides cloud infrastructure services, including Cloud VPS, dedicated servers and web hosting, which aligns with the scope of the existing provider list.

Please let me know if any changes are needed. Thank you for maintaining this project.