### PR TITLE
Add Drumbeats to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [Drumbeats](https://drumbeats.io) - Cron, heartbeat, and uptime monitoring with status pages. Free for 50 monitors.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
Adds **Drumbeats** to the Observability & Monitoring category.

- **Name:** Drumbeats
- **Category:** Observability & Monitoring
- **Link:** https://drumbeats.io
- Hosted cron, heartbeat, and HTTP uptime monitoring with incident management and status pages. Free for up to 50 monitors.

Description kept under 80 chars and ends with a full stop, per the contribution guidelines.