### PR TITLE
Add keyrotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Git Secret](https://github.com/sobolevn/git-secret) - A bash-tool to store your private data inside a git repository.
 - [Infisical](https://github.com/Infisical/infisical) - Open source end-to-end encrypted secrets sync for teams and infrastructure.
 - [Lade](https://github.com/zifeo/lade) - Automatically load secrets from your preferred vault as environment variables.
+- [keyrotate](https://github.com/sophie4869/keyrotate) - Rotate across Vercel/Cloud Run/Atlas + local, sharable across repos, agent-safe.
 
 ## Security
 


### PR DESCRIPTION
Adding [keyrotate](https://github.com/sophie4869/keyrotate) to the **Secret Management** section.

**What it is:** open-source (MIT) bash CLI for rotating and syncing secrets across the places they physically live — Vercel env, Google Cloud Run env, GCP Secret Manager, Koyeb, GitHub Actions secrets (across N repos), MongoDB Atlas user passwords, remote hosts over SSH, and local `.env` files — from a single values-free JSON config per project.

**Why it's a fit for this section:** existing entries (Vault, SOPS, Infisical, Lade) focus on **encrypted storage + runtime fetch**. keyrotate solves a complementary problem: **rotation + synchronization across ~8 different sinks** for real personal / small-team infrastructure where one MONGODB_URI lives in 4 places and an e2e test token lives across 8 repos' Actions secrets. It also adds **cross-project propagation** so a JWT signing key owned by one auth service can automatically land in all its downstream verifiers.

**Meets contribution guidelines:**
- MIT licensed, hosted at https://github.com/sophie4869/keyrotate
- Format: `[NAME](LINK) - DESCRIPTION.` (79-char description, ends with period, no trailing whitespace)
- Added at end of the Secret Management section (per the "add at bottom" rule)
- Single commit, imperative title (`Add keyrotate to Secret Management`)

Happy to adjust wording, placement, or trim further if useful.