### PR TITLE
Add TheCodeForge to Online Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 ### Online Platforms
 
 - [Cloud Native Playground](https://play.meshery.io) - The Meshery CNCF Playground is an awesome and free resource featuring a live Kubernetes cluster where any CNCF project can be configured and deployed. It is a fantastic interactive learning platform for exploring cloud native technologies.
+- [TheCodeForge](https://thecodeforge.io/) - 1,700+ production-grade DevOps, system design, and programming tutorials with real incident stories and structured learning paths.
 
 ## Contributing
 


### PR DESCRIPTION
Add [TheCodeForge](https://thecodeforge.io/) — 1,700+ free production-grade tutorials across DevOps, system design, Python, Java, and more, each with real incident stories and structured learning paths.