### PR TITLE
Add PatchRail to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [PatchRail](https://github.com/patchrail/patchrail) - Local-first CLI that explains failed CI logs and how to reproduce them.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds one entry to **Productivity Tools**:

`- [PatchRail](https://github.com/patchrail/patchrail) - Local-first CLI that explains failed CI logs and how to reproduce them.`

- Application: PatchRail
- Category: Productivity Tools
- Project: https://github.com/patchrail/patchrail

Guideline checklist:
- [x] Format `[RESOURCE](LINK) - DESCRIPTION.`; description <80 chars, ends with a full stop.
- [x] Single commit for one category; imperative PR title.
- [x] Searched previous suggestions — no duplicate.
- [x] Spelling/grammar checked; no trailing whitespace.