### PR TITLE
Add Dada Cloud to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Kinsta](https://kinsta.com/application-hosting/) - Create and deploy web applications and databases in minutes.
 - [Equinix](https://www.equinix.com/) - Global data center and colocation provider for enterprise network and cloud computing.
 - [Clever Cloud](https://clever.cloud/) - European Platform as a Service (PaaS) with managed databases and object storage.
+- [Dada Cloud](https://cloud.dada-tuda.ru) - Russia-based Platform as a Service (PaaS) with git push deploys, managed PostgreSQL, and HTTPS domains.
 
 ## Open Source Cloud Platforms
 


### PR DESCRIPTION
Adds Dada Cloud to the Cloud Platforms section, alongside the existing regional-PaaS entry Clever Cloud. Dada Cloud is a Russia-based Platform as a Service with git push deploys, managed PostgreSQL, and HTTPS domains. Live at https://cloud.dada-tuda.ru. One line added.