### PR TITLE
Add Tura to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
-- [Tura](https://github.com/Tura-AI/tura) - Local coding agent with CLI, TUI, and GUI workspaces.
+- [Tura](https://github.com/Tura-AI/tura) - Local, open-source coding agent that understands a repo before changing it.
 
 ## Continuous Integration & Delivery
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [Tura](https://github.com/Tura-AI/tura) - Local coding agent with CLI, TUI, and GUI workspaces.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
## Application

- Name: Tura
- Category: Productivity Tools
- Open-source project: https://github.com/Tura-AI/tura

**Tura: 16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

Benchmark evidence: https://turaai.net/benchmark

## Listing copy

`Local, open-source coding agent that understands a repo before changing it.`

This is a 75-character compression of the README positioning to satisfy the repository's mandatory description limit of fewer than 80 characters.

## Validation

- Added one entry at the end of Productivity Tools
- Used the required `[RESOURCE](LINK) - DESCRIPTION.` format
- Confirmed the description is under 80 characters
- Checked the README, issues, and pull requests for an existing Tura entry
- Ran `git diff --check`

## Disclosure

I maintain Tura. AI assistance was used to research the contribution scope, update the listing copy, and verify the final change.