### PR TITLE
Add Netruneer Email DNS Starter to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC with API for CI/CD integration.
+- [Netruneer Email DNS Starter](https://github.com/alexispomares/netruneer-email-dns-starter) - One-edit GitHub Actions template for bounded SPF, DMARC and MX checks.
 
 ## Sharing
 


### PR DESCRIPTION
## What changed

Adds [Netruneer Email DNS Starter](https://github.com/alexispomares/netruneer-email-dns-starter) to the **Security** category.

## Why

The MIT-licensed starter is a one-edit GitHub Actions template for bounded SPF, DMARC, and MX observations. Its manual-only workflow declares empty permissions, reads no repository content or secrets, and keeps raw DNS records out of the Step Summary.

## Affiliation disclosure

I own and maintain Netruneer and am submitting this listing for my own open-source project.

## Checks

- One Security-category entry
- Description under 80 characters and ending with a full stop
- Public open-source project link
- Initial starter workflow smoke test succeeded
