### PR TITLE
Add Rasptele to observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [Rasptele](https://github.com/maddhruv/rasptele) - Monitor Raspberry Pi Docker services through Telegram.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
## What

Add Rasptele to the Observability & Monitoring section.

## Why

Rasptele is an Apache-2.0 licensed monitoring tool for Raspberry Pi Docker servers. It reports host and container health through Telegram, supports allowlisted container restarts, and provides stateful alerts and audit history without requiring an exposed dashboard.

The entry follows the requested short description format and links directly to the open-source project.
