### PR TITLE
Add CI Rescue to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [CI Rescue](https://yunczo.github.io/ci-rescue-service/) - Browser-only GitHub Actions log analyzer and Node 24 workflow checker.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds **CI Rescue** to **Productivity Tools**. The public page provides a browser-only GitHub Actions log analyzer and Node 24 workflow checker; both are free and no-account.

Open-source project: https://github.com/Yunczo/ci-rescue-service

Disclosure: I maintain CI Rescue and am submitting this one entry.