### PR TITLE
Add OpsCanopy to Continuous Integration & Delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Github actions](https://github.com/features/actions) - GitHub Actions makes it easy to automate all your software workflows, now with world-class CI/CD.
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.
+  - [OpsCanopy](https://opscanopy.com/) - Browser-based DevOps utilities: GitHub Actions and GitLab CI validators, expression and trigger testers, cron, subnet and JWT tools. No signup, runs client-side.
   - [GitLab Pipelines by puzl.cloud](https://puzl.cloud/products/run-my-job/) - Blazing-fast, cost-effective execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
 
 ## Source Code Management


### PR DESCRIPTION
Adds OpsCanopy, a set of 29 browser-based DevOps utilities.

Relevant to this section: GitHub Actions workflow validator, GitHub Actions
expression and trigger tester, GitLab CI validator, and a Docker run to Compose
converter. Others cover observability (PromQL, LogQL, Alertmanager routing,
Prometheus relabeling), networking (subnet, CIDR, PTR) and encoding.

Everything runs client-side with no signup and no upload — the site's CSP sets
`connect-src 'self'`, so pasted configs cannot leave the browser. That is the
main reason it exists: the equivalent hosted validators all POST your CI config
to a server, which is awkward when it contains internal hostnames and secret
names.

Disclosure: I built this.