### PR TITLE
Add OpsCanopy to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [OpsCanopy](https://opscanopy.com/) - Browser-based DevOps utilities: GitHub Actions and GitLab CI validators, expression and trigger testers, PromQL/LogQL explainers, subnet, cron and JWT tools. No signup, runs client-side.
 
 ## Continuous Integration & Delivery
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
-- [OpsCanopy](https://opscanopy.com/) - Browser-based DevOps utilities: GitHub Actions and GitLab CI validators, expression and trigger testers, PromQL/LogQL explainers, subnet, cron and JWT tools. No signup, runs client-side.
+- [OpsCanopy](https://opscanopy.com) - Client-side DevOps and SRE tools; nothing you paste leaves the browser.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds OpsCanopy, a set of 29 browser-based DevOps utilities.

Placed in Productivity Tools rather than Continuous Integration & Delivery: that
section lists CI/CD platforms (Jenkins, Circle CI, Travis) and OpsCanopy is not
one — it is a set of validators and testers you use alongside them. The closest
existing entry is YAML Validator, directly above.

Relevant tools: GitHub Actions workflow validator, GitHub Actions expression and
trigger tester, GitLab CI validator, Docker run to Compose converter, PromQL and
LogQL explainers, Prometheus relabel and Alertmanager route testers, plus
subnet/CIDR, cron and JWT utilities.

Everything runs client-side — no signup, no upload. The site's CSP sets
`connect-src 'self'`, so a pasted config cannot leave the browser. That is the
reason it exists: hosted CI validators generally POST your config to a server,
which is awkward when it contains internal hostnames and secret names.

Disclosure: I built this.