### PR TITLE
Add go-exec-format-doctor to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [go-exec-format-doctor](https://github.com/soul-sol/go-exec-format-doctor) - Diagnose binary format and architecture mismatches without execution.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
## Resource

- Application: go-exec-format-doctor
- Category: Productivity Tools
- Open source project: https://github.com/soul-sol/go-exec-format-doctor

`go-exec-format-doctor` inspects local ELF, Mach-O, PE, and script files to diagnose binary-format and CPU-architecture mismatches without executing the target.

This PR adds one concise entry following the requested `[RESOURCE](LINK) - DESCRIPTION.` format. The description is 69 characters and ends with a full stop. I maintain the submitted open-source project.