### PR TITLE
Add Nimbus to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [Nimbus](https://github.com/nimbus-agent/Nimbus) - Local-first AI agent that indexes ~80 dev and infra services on your machine.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds Nimbus to the Productivity Tools section.

- Application: Nimbus
- Category: Productivity Tools
- Project page: https://github.com/nimbus-agent/Nimbus

Nimbus is a local-first AI agent for on-call and platform engineers. It runs as a headless gateway plus CLI on the engineer's own machine and builds a private SQLite index across ~80 developer and infrastructure services — GitHub, GitLab, Jira, Slack, PagerDuty, Datadog, Sentry and more — so incident questions like "what deployed last, which commit, which ticket" are answered in one query instead of seven browser tabs.

Every outbound action passes a human-in-the-loop consent gate, and credentials stay in the OS keystore. Open source (AGPL-3.0), Windows/macOS/Linux.

Description is 77 characters and ends with a full stop, per the contribution guidelines.
