### PR TITLE
Add AI Economics Tools to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [AI Economics Tools](https://piszczek.pl/tools) - MCP server and web calculators for AI cost and energy, by Michał Piszczek.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
**App name:** AI Economics Tools
**Category:** Productivity Tools
**Project link:** https://piszczek.pl/tools (source: https://github.com/pich/ai-economics-tools, MCP server: https://github.com/pich/ai-economics-mcp)

Twelve browser-based calculators by Michał Piszczek for the numbers that now show up in every infrastructure budget: token cost across GPT/Claude/Gemini/DeepSeek, context-window sizing, fully-loaded agent-hour cost, model-routing savings, LLM energy and CO₂. No sign-up, no key, nothing stored. MIT-licensed, and the same math is reachable as a free HTTP API with an OpenAPI 3.1 spec and as an MCP server on npm.

Format check: single entry appended to the end of the section, `[RESOURCE](LINK) - DESCRIPTION.` with a full stop, description 74 characters.