### PR TITLE
Add Granite to Applications Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [vCluster](https://vcluster.sh/)- A open source project that helps you create virtual clusters.
 - [devpod](https://devpod.sh/) - Open-source, codebases-like tool that creates reproducible developer environments, supporting numerous providers (Kubernetes, AWS, GCP, etc.).
 - [KubeStellar Console](https://console.kubestellar.io/) - Open source AI-powered multi-cluster Kubernetes dashboard with real-time observability, AI-guided operations, and 20+ CNCF integrations (Argo, Kyverno, Prometheus, Grafana, Istio, Flux, Falco, OPA/Gatekeeper). CNCF Sandbox project.
+- [Granite](https://granite.so/) - Deploy apps from Git or a Docker image with managed databases.
 
 ## Internal Developer Platforms
 


### PR DESCRIPTION

Adds Granite to `## Applications Platforms`.

```
- [Granite](https://granite.so/) - Deploy apps from Git or a Docker image with managed databases.
```

### What it is

An application platform: you deploy from a Git repository or any Docker image, and run managed PostgreSQL, MySQL, MongoDB and Valkey, S3-compatible object storage with a CDN, and a private Docker registry next to the app. HTTP services, background workers and cron jobs are separate resource types rather than one process shape you have to work around.

It sits in the same category as Cloud 66 and Cycle.io, already in this section — managed platform rather than raw infrastructure, which is why this is `Applications Platforms` and not `Cloud Platforms`.

### Guidelines

- Format `[RESOURCE](LINK) - DESCRIPTION.`, description is 62 characters, ends with a full stop.
- Appended at the end of the section, since it is not alphabetically ordered.
- Single commit, single category.
- Imperative PR title.

### Disclosure

I work on Granite — self-submission, flagging it rather than leaving you to spot it.

Granite is a commercial hosted service, not an open source project, so I cannot give you a repository link the way your contributing notes suggest. If that rules it out, say so and I will close this myself; I see the section already carries commercial entries, which is what made me think it was in scope.

This PR was assisted by AI (Claude) for research and drafting. The claims are mine and are verifiable at https://granite.so.
