### PR TITLE
Add OutageDeck to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Cachet](https://github.com/CachetHQ/Cachet) - Beautiful and powerful open-source status page system.
   - [StatusPal](https://statuspal.io/?utm_source=github.com&utm_medium=referral&utm_campaign=awesome-devops) - Communicate incidents and maintenance effectively with a beautiful hosted status page.
   - [Instatus](https://instatus.com) - Quick and beautiful status page.
+  - [OutageDeck](https://outagedeck.com/?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome_devops) - Normalized cloud and SaaS status aggregation for incident response.
   - [Oxmgr](https://github.com/Vladimir-Urik/OxMgr) - Lightweight Rust process manager and PM2 alternative. 42x faster crash recovery, 19x lower memory usage. Manages Node.js, Python, Go, and any executable on Linux, macOS, and Windows.
 
 ## Service Discovery & Service Mesh


### PR DESCRIPTION
Adds **OutageDeck** to the `Observability & Monitoring / Status` category. The entry follows the required resource format, its description is 67 characters, and the linked page returns HTTP 200.

OutageDeck normalizes vendor-published status and incident context for cloud and SaaS providers. Its open-source integration surfaces include:

- Prometheus exporter and Grafana dashboard: https://github.com/outagedeck/prometheus-exporter
- CLI: https://github.com/outagedeck/cli
- Home Assistant integration: https://github.com/outagedeck/home-assistant
- MCP server: https://github.com/outagedeck/mcp

This is a single-category, single-entry change.