### PR TITLE
Add Latchkey to Continuous Integration & Delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Kraken CI](https://kraken.ci/) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing.
   - [Earthly](https://earthly.dev/) - Develop CI/CD pipelines locally and run them anywhere.
   - [GitLab Pipelines by puzl.cloud](https://puzl.cloud/products/run-my-job/) - Blazing-fast, cost-effective execution layer for GitLab CI/CD pipeline jobs, offering per-second billing and k8s API for runner management.
+  - [Latchkey](https://latchkey.dev) - Managed GitHub Actions runners that repair failing builds mid-run.
 
 ## Source Code Management
 


### PR DESCRIPTION
Adds **Latchkey** under *Continuous Integration & Delivery > Public Services*.

Link: https://latchkey.dev

Managed ephemeral Linux runners for GitHub Actions that diagnose and repair a failing step at runtime and retry it, rather than just failing the job. Closest existing entry in the section is GitLab Pipelines by puzl.cloud, which is the same idea (a managed execution layer for pipeline jobs) for GitLab CI.

Description is 66 characters and ends with a full stop, per the contribution guidelines.

Disclosure: I'm a co-founder.