### PR TITLE
Add core CNCF and industry-standard tools to existing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,12 +302,14 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Elasticsearch](https://www.elastic.co/products/elasticsearch) - Distributed, RESTful search and analytics engine capable of addressing a growing number of use cases.
   - [MongoDB](https://www.mongodb.com/) - General purpose, document-based, distributed database built for modern applications.
   - [Rethinkdb](https://github.com/rethinkdb/rethinkdb) - Open-source database for the real-time web.
+  - [ClickHouse](https://clickhouse.com/) - Column-oriented database for real-time analytical reports.
   - Key-Value
     - [Couchbase](https://www.couchbase.com/) - Distributed  multi-model NoSQL document-oriented database that is optimized for interactive applications.
     - [Leveldb](https://github.com/google/leveldb) - Fast key-value storage library.
     - [Redis](https://redis.io/) - In-memory data structure store, used as a database, cache and message broker.
     - [RocksDB](https://rocksdb.org/) - A library that provides an embeddable, persistent key-value store for fast storage.
     - [Etcd](https://github.com/etcd-io/etcd) - Distributed reliable key-value store for the most critical data of a distributed system.
+    - [Valkey](https://valkey.io/) - High-performance key/value datastore forked from Redis.
 
 ## Observability & Monitoring
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [vCluster](https://vcluster.sh/)- A open source project that helps you create virtual clusters.
 - [devpod](https://devpod.sh/) - Open-source, codebases-like tool that creates reproducible developer environments, supporting numerous providers (Kubernetes, AWS, GCP, etc.).
 - [KubeStellar Console](https://console.kubestellar.io/) - Open source AI-powered multi-cluster Kubernetes dashboard with real-time observability, AI-guided operations, and 20+ CNCF integrations (Argo, Kyverno, Prometheus, Grafana, Istio, Flux, Falco, OPA/Gatekeeper). CNCF Sandbox project.
+- [Kind](https://kind.sigs.k8s.io/) - Run local Kubernetes clusters using Docker container nodes.
 
 ## Internal Developer Platforms
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Integrity](http://integrity.github.io/) - Continuous Integration server.
   - [Zuul](https://zuul-ci.org/) - drives continuous integration, delivery, and deployment systems with a focus on project gating.
   - [Argo](https://argoproj.github.io/) - Open Source Kubernetes native workflows, events, CI and CD.
+  - [Argo CD](https://argo-cd.readthedocs.io/) - declarative GitOps continuous delivery for Kubernetes.
   - [Strider](https://strider-cd.github.io/) - Continuous Deployment/Continuous Integration platform.
   - [Evergreen](https://github.com/evergreen-ci/evergreen) - A Distributed Continuous Integration System from MongoDB.
   - [werf](https://werf.io/) - Open Source CI/CD tool for building Docker images & deploying them to Kubernetes using a GitOps approach.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [OpenTelemetry](https://opentelemetry.io/) - Vendor-neutral framework for traces, metrics and logs.
+- [Jaeger](https://www.jaegertracing.io/) - Open source, end-to-end distributed tracing platform.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.
@@ -346,6 +348,8 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Netdata](https://www.netdata.cloud/) - Instantly diagnose slowdowns and anomalies in your infrastructure.
   - [Freeboard](https://github.com/Freeboard/freeboard) - Real-time dashboard builder for IOT and other web mashups.
   - [Autometrics](https://autometrics.dev/) - An open-source micro framework for observability.
+  - [Thanos](https://thanos.io/) - Highly available Prometheus setup with long-term storage.
+  - [VictoriaMetrics](https://victoriametrics.com/) - Fast, cost-effective time series database and monitoring.
 - Logs Management
   - [Anthracite](https://github.com/Dieterbe/anthracite) - An event/change logging/management app.
   - [Graylog](https://github.com/Graylog2/graylog2-server) - Free and open source log management.

--- a/README.md
+++ b/README.md
@@ -468,6 +468,12 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC with API for CI/CD integration.
+- [Trivy](https://trivy.dev/) - Scanner for vulnerabilities and misconfigurations in code and containers.
+- [Falco](https://falco.org/) - Cloud native runtime security and threat detection.
+- [Open Policy Agent](https://www.openpolicyagent.org/) - General-purpose policy engine for cloud native environments.
+- [Kyverno](https://kyverno.io/) - Policy engine designed for Kubernetes.
+- [Sigstore](https://www.sigstore.dev/) - Signing, verification and provenance for software artifacts.
+- [Gitleaks](https://github.com/gitleaks/gitleaks) - Detect and prevent hardcoded secrets in git repositories.
 
 ## Sharing
 

--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [SoftEther](https://www.softether.org/) - An Open-Source Free Cross-platform Multi-protocol VPN Program.
 as an academic project from University of Tsukuba, under the Apache License 2.0.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [WireGuard](https://www.wireguard.com/) - Fast, modern and secure VPN tunnel.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [k9s](https://k9scli.io/) - Terminal UI to interact with your Kubernetes clusters.
 
 ## Continuous Integration & Delivery
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Capistrano](https://capistranorb.com/) - A remote server automation and deployment tool.
 - [Mina](http://nadarei.co/mina/) - Really fast deployer and server automation tool.
 - [Terraform](https://www.terraform.io/) - use Infrastructure as Code to provision and manage any cloud, infrastructure, or service.
+- [OpenTofu](https://opentofu.org/) - Open source, community-driven fork of Terraform.
 - [Pulumi](https://www.pulumi.com/) - Modern infrastructure as code platform that allows you to use familiar programming languages and tools to build, deploy, and manage cloud infrastructure.
 - [Packer](https://www.packer.io/) - Build Automated Machine Images.
 - [Vagrant](https://www.vagrantup.com/) - Development Environments Made Easy.
@@ -191,6 +192,9 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Terrateam](https://terrateam.io) - Open-source alternative to Terraform Cloud/Enterprise, GitOps-first with native GitHub integration and designed for scale, security, and reliability.
 - [Scalr](https://scalr.com/) - Drop-in Terraform Cloud alternative, usage-based pricing, unlimited concurrency.
 - [CloudRay](https://cloudray.io) - Centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.
+- [Helm](https://helm.sh/) - The package manager for Kubernetes.
+- [Kustomize](https://kustomize.io/) - Template-free customization of Kubernetes configuration.
+- [Crossplane](https://www.crossplane.io/) - Build control planes to manage infrastructure with Kubernetes APIs.
 
 ## Productivity Tools
 


### PR DESCRIPTION
This adds 20 widely-adopted tools that the list is currently missing. Every entry is either a CNCF graduated/incubating project or a de-facto industry standard — no vendor submissions, no new categories, and no changes to existing entries.

The gaps that stood out most: there was no Kubernetes package manager listed at all, no distributed tracing tool of any kind, and the Security section had only two entries.

One commit per category, per the contribution guidelines.

### Automation & Orchestration
- [Helm](https://helm.sh/) — the package manager for Kubernetes ([github.com/helm/helm](https://github.com/helm/helm), CNCF graduated)
- [Kustomize](https://kustomize.io/) — template-free Kubernetes configuration customization ([github.com/kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize), Kubernetes SIG)
- [OpenTofu](https://opentofu.org/) — community-driven fork of Terraform ([github.com/opentofu/opentofu](https://github.com/opentofu/opentofu), Linux Foundation)
- [Crossplane](https://www.crossplane.io/) — build control planes with Kubernetes APIs ([github.com/crossplane/crossplane](https://github.com/crossplane/crossplane), CNCF graduated)

`OpenTofu` is placed directly after the existing Terraform entry since they're directly related.

### Continuous Integration & Delivery (On-premises)
- [Argo CD](https://argo-cd.readthedocs.io/) — declarative GitOps CD for Kubernetes ([github.com/argoproj/argo-cd](https://github.com/argoproj/argo-cd), CNCF graduated)

Only the `Argo` umbrella project was listed; Argo CD is the component most people mean when referencing GitOps CD, so it seemed worth calling out explicitly alongside the existing Flux entry.

### Observability & Monitoring
- [OpenTelemetry](https://opentelemetry.io/) — vendor-neutral traces, metrics and logs ([github.com/open-telemetry](https://github.com/open-telemetry), CNCF incubating)
- [Jaeger](https://www.jaegertracing.io/) — end-to-end distributed tracing ([github.com/jaegertracing/jaeger](https://github.com/jaegertracing/jaeger), CNCF graduated)
- [Thanos](https://thanos.io/) — HA Prometheus with long-term storage ([github.com/thanos-io/thanos](https://github.com/thanos-io/thanos), CNCF incubating) — *Metrics sub-list*
- [VictoriaMetrics](https://victoriametrics.com/) — time series database and monitoring ([github.com/VictoriaMetrics/VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)) — *Metrics sub-list*

OpenTelemetry is the current standard for instrumentation, and the list previously had no tracing tools at all.

### Security
- [Trivy](https://trivy.dev/) — vulnerability and misconfiguration scanner ([github.com/aquasecurity/trivy](https://github.com/aquasecurity/trivy))
- [Falco](https://falco.org/) — cloud native runtime security ([github.com/falcosecurity/falco](https://github.com/falcosecurity/falco), CNCF graduated)
- [Open Policy Agent](https://www.openpolicyagent.org/) — general-purpose policy engine ([github.com/open-policy-agent/opa](https://github.com/open-policy-agent/opa), CNCF graduated)
- [Kyverno](https://kyverno.io/) — policy engine for Kubernetes ([github.com/kyverno/kyverno](https://github.com/kyverno/kyverno), CNCF incubating)
- [Sigstore](https://www.sigstore.dev/) — artifact signing and provenance ([github.com/sigstore](https://github.com/sigstore), OpenSSF)
- [Gitleaks](https://github.com/gitleaks/gitleaks) — detect hardcoded secrets in git repos

This section had only `checkov` and `IntoDNS.ai`, so it was the largest single gap.

### Applications Platforms
- [Kind](https://kind.sigs.k8s.io/) — local Kubernetes clusters using Docker nodes ([github.com/kubernetes-sigs/kind](https://github.com/kubernetes-sigs/kind), Kubernetes SIG)

### Productivity Tools
- [k9s](https://k9scli.io/) — terminal UI for Kubernetes clusters ([github.com/derailed/k9s](https://github.com/derailed/k9s))

### Databases
- [ClickHouse](https://clickhouse.com/) — column-oriented analytical database ([github.com/ClickHouse/ClickHouse](https://github.com/ClickHouse/ClickHouse)) — *Non-relational*
- [Valkey](https://valkey.io/) — key/value datastore forked from Redis ([github.com/valkey-io/valkey](https://github.com/valkey-io/valkey), Linux Foundation) — *Key-Value*

### VPN
- [WireGuard](https://www.wireguard.com/) — fast, modern and secure VPN tunnel ([www.wireguard.com](https://www.wireguard.com/))

WireGuard was previously only referenced inside the Firezone description.

---

**Notes for review**

- **Helm placement is open to your preference.** I put Helm and Kustomize in `Automation & Orchestration` because that section already holds the deploy/config tooling (Terraform, Pulumi, KubeVela, Score, Atlantis). The `Package Management & System configuration` section is arguably a better semantic fit for Helm, but its description is scoped to OS-level isolated package builds. Happy to move them if you'd rather.
- Deliberately **not** included: OpenBao and External Secrets Operator, since #502 already proposes those.
- All descriptions follow the `[RESOURCE](LINK) - DESCRIPTION.` format and are under 80 characters.
- Verified all 20 new links return HTTP 200, and that `mkdocs build` still succeeds.
- No existing entries were modified and no new sections were added.
