### PR TITLE
Add Nexus Shell to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
+- [Nexus Shell](https://nexusshell.app/) - Native macOS SSH client with SFTP, monitoring, and Docker tools.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
 
 ## Continuous Integration & Delivery


### PR DESCRIPTION
## Summary

- Add Nexus Shell to the Productivity Tools section.
- Use the official product page and a 64-character objective description.

## Disclosure

I am the developer of Nexus Shell. It is a proprietary native macOS SSH client; the free tier provides basic personal SSH. Public releases and changelogs are available at https://github.com/viewer12/Nexus-Shell-Releases. This contribution was prepared with OpenAI Codex assistance and reviewed against the repository guidelines.

## Checks

- Confirmed Nexus Shell is not already listed.
- `git diff --check` passes.
- Product and releases links return HTTP 200.