### PR TITLE
Add DeusAcc free n8n workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Instatus](https://instatus.com) - Quick and beautiful status page.
   - [Oxmgr](https://github.com/Vladimir-Urik/OxMgr) - Lightweight Rust process manager and PM2 alternative. 42x faster crash recovery, 19x lower memory usage. Manages Node.js, Python, Go, and any executable on Linux, macOS, and Windows.
 - [n8n Uptime Ping Alert](https://github.com/DeusAcc/n8n-uptime-ping-alert) - Free n8n workflow that checks a site every 5 minutes and alerts on Telegram only on state change.
+- [n8n Uptime Ping Alert](https://github.com/DeusAcc/n8n-uptime-ping-alert) - Free n8n workflow that checks a site every 5 minutes and alerts on Telegram only on state change.
 
 ## Service Discovery & Service Mesh
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [StatusPal](https://statuspal.io/?utm_source=github.com&utm_medium=referral&utm_campaign=awesome-devops) - Communicate incidents and maintenance effectively with a beautiful hosted status page.
   - [Instatus](https://instatus.com) - Quick and beautiful status page.
   - [Oxmgr](https://github.com/Vladimir-Urik/OxMgr) - Lightweight Rust process manager and PM2 alternative. 42x faster crash recovery, 19x lower memory usage. Manages Node.js, Python, Go, and any executable on Linux, macOS, and Windows.
+- [n8n Uptime Ping Alert](https://github.com/DeusAcc/n8n-uptime-ping-alert) - Free n8n workflow that checks a site every 5 minutes and alerts on Telegram only on state change.
 
 ## Service Discovery & Service Mesh
 


### PR DESCRIPTION
Adding a free, open-source n8n workflow (https://github.com/DeusAcc/n8n-uptime-ping-alert) that fits this list.

The repo README documents usage and also links to a paid bundle at https://negozio.91.99.198.106.sslip.io/?src=wmariuss-awesome-devops — the specific workflow linked here is itself free (no account/paywall).

Happy to adjust placement/wording if it doesn't fit.