### PR TITLE
Add Production Readiness Checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 ### Online Platforms
 
 - [Cloud Native Playground](https://play.meshery.io) - The Meshery CNCF Playground is an awesome and free resource featuring a live Kubernetes cluster where any CNCF project can be configured and deployed. It is a fantastic interactive learning platform for exploring cloud native technologies.
+- [Production Readiness Checklist](https://github.com/MarinJursic/production-readiness-checklist) - Technology-neutral production readiness review checklist.
 
 ## Contributing
 


### PR DESCRIPTION
## What

Adds the Production Readiness Checklist to Resources → Online Platforms.

## Why

The free, MIT-licensed resource provides a technology-neutral review path across DevOps, delivery, reliability, security, testing, and operations. It gives teams a practical checklist to use before and after production releases.

## Impact

Adds one resource link. Existing entries are unchanged.

## Checks

- Searched existing suggestions for duplicate names and links
- Used the required resource, link, and short-description format
- Kept the description below 80 characters and ended it with a period
- Verified the change with `git diff --check`
