### PR TITLE
Add stackql under Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 *Observability, Monitoring, Metrics/Metrics collection and Alerting tools.*
 
 - [Steampipe](https://steampipe.io/) - The universal SQL interface for any cloud API, & cloud intelligence dashboards extensible w/ HCL+SQL.
+- [stackql](https://github.com/stackql/stackql) - SQL for cloud APIs. Query AWS, GCP, Azure and dozens of other providers with SQL. Includes an MCP server for agent access.
 - [Sensu](https://sensu.io/) - Simple. Scalable. Multi-cloud monitoring.
 - [Alerta](https://github.com/alerta/alerta) - Scalable, minimal configuration and visualization monitoring system.
 - [Cabot](https://github.com/arachnys/cabot) - Self-hosted, easily-deployable monitoring and alerts service.


### PR DESCRIPTION
Adds stackql, an open-source SQL query engine for cloud APIs (AWS, GCP, Azure, and 40+ other providers), with an MCP server for agent access.

Placed alongside Steampipe in the Observability & Monitoring section since both provide the same category of functionality (SQL-based querying of cloud APIs).

GitHub: https://github.com/stackql/stackql
Docs: https://stackql.io