### PR TITLE
Add CronAlive to observability tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Canary Checker](https://canarychecker.io) - Open source health check platform.
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
-- [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [Middleware](https://middleware.io) - A full-stack cloud observability platform.
+- [CronAlive](https://cronalive.com) - Heartbeat monitoring for cron jobs, with HTTP uptime and TLS expiry checks. Free tier, hosted.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
Adds CronAlive to Observability & Monitoring.

It's a heartbeat monitor for cron jobs and scheduled tasks — it alerts
when an expected ping stops arriving — plus HTTP uptime checks
confirmed from a second region and TLS expiry warnings. Hosted, with a
free tier for 10 checks.

Sits alongside Healthchecks in the same category.

Note: the editor also stripped a trailing space at the end of the
Middleware line. Happy to revert that if you'd rather keep the diff to
one line.