### PR TITLE
Add DevOps Daily to Online Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 
 ### Online Platforms
 
+- [DevOps Daily](https://devops-daily.com) - Free and open source learning site with 50+ interactive simulators (Docker, Kubernetes, Linux, Terraform, SQL), quizzes and exercises. No signup required.
 - [Cloud Native Playground](https://play.meshery.io) - The Meshery CNCF Playground is an awesome and free resource featuring a live Kubernetes cluster where any CNCF project can be configured and deployed. It is a fantastic interactive learning platform for exploring cloud native technologies.
 
 ## Contributing


### PR DESCRIPTION
Adds DevOps Daily to Online Platforms: free interactive simulators, quizzes and exercises for Docker, Kubernetes, Linux, Terraform and more, no signup, open source (https://github.com/The-DevOps-Daily/devops-daily).

Disclosure: I help maintain the site.
