### PR TITLE
Add otp-watch to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Zabbix](https://www.zabbix.com/) - Mature and effortless monitoring solution for network monitoring and application monitoring.
 - [Glances](https://github.com/nicolargo/glances) - Monitoring information through a curses or Web based interface.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - Cron monitoring tool.
+- [otp-watch](https://github.com/flovoice53-tech/otp-watch) - Synthetic monitoring for SMS/email verification delivery: confirms an OTP/verification code actually arrived, not just that your API responded.
 - [Bolo](http://bolo.niftylogic.com/) - Building distributed, scalable monitoring systems.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.


### PR DESCRIPTION
otp-watch is a small hosted service that answers a question standard synthetic monitoring doesn't: did the OTP/verification SMS or email a signup flow sent actually arrive, and how fast? You get a real phone number or disposable email, trigger your own send to it, then poll for arrival/latency. Fits right next to Healthchecks (cron delivery monitoring) as a delivery-confirmation tool rather than an infra-metrics one.

Repo: https://github.com/flovoice53-tech/otp-watch
Live: https://otpwatch.flo-voice1.com