### PR TITLE
add envsetup.dev to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [envsetup.dev](https://envsetup.dev) - Generates a Dockerfile, docker-compose.yml and .env for 23+ languages.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
envsetup.dev generates a Dockerfile, docker-compose.yml and .env.example for 23+ languages/frameworks, via a free CLI (`npx @envsetup/cli init`) or web UI. Open source: https://github.com/kbrahmateja/v0-envsetup-dev

Added to Productivity Tools, one entry, per the contributing guidelines.