### PR TITLE
Add arch-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [arch-map](https://github.com/fabiocicerchia/arch-map) - Living C4 architecture diagrams from Terraform state + live Kubernetes, committed as Mermaid.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Adds [arch-map](https://github.com/fabiocicerchia/arch-map) under **Productivity Tools**.

> Living C4 architecture diagrams from Terraform state + live Kubernetes, committed as Mermaid.

One addition in a single commit, formatted and ordered to match the surrounding entries in that section.