### PR TITLE
Add Nutilz to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [Nutilz](https://nutilz.com) - Free browser-based developer utilities including Dockerfile generator, cron parser, regex tester, JSON formatter, and security generators.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Add [Nutilz](https://nutilz.com) — a collection of free browser-based developer utilities including Dockerfile generator, cron parser, regex tester, JSON formatter, and security generators. All tools run client-side with no sign-up required.