### PR TITLE
Add devops-skills to Code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [MeshMap](https://layer5.io/cloud-native-management/meshmap) - World’s only visual designer for Kubernetes and cloud native applications. Design, deploy, and manage your Kubernetes-based, cloud native deployments allowing you to speed up infrastructure configuration.
 - [Potpie](https://potpie.ai) - AI agent that understands your code changes and computes the blast radius of your changes. 
 - [CodeRabbit](https://coderabbit.ai) - AI-powered code review tool that integrates with GitHub. It automates routine checks, provides intelligent feedback, and helps maintain consistent code quality.
+- [devops-skills](https://github.com/anmolnagpal/devops-skills) - AI-agent DevOps review skills for Claude Code, Cursor, and Codex.
 
 ## Distributed Messaging
 


### PR DESCRIPTION
Adds **devops-skills** to Code review — AI-agent DevOps review skills for Claude Code, Cursor, and Codex (Terraform, Kubernetes, Docker, CI/CD, security). Fits alongside Potpie and CodeRabbit. Findings carry stable rule IDs and are fixture-tested. MIT, v1.5.0. https://github.com/anmolnagpal/devops-skills