### PR TITLE
Add Pharos to Observability & Monitoring/Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
   - [Cachet](https://github.com/CachetHQ/Cachet) - Beautiful and powerful open-source status page system.
   - [StatusPal](https://statuspal.io/?utm_source=github.com&utm_medium=referral&utm_campaign=awesome-devops) - Communicate incidents and maintenance effectively with a beautiful hosted status page.
   - [Instatus](https://instatus.com) - Quick and beautiful status page.
+  - [Pharos](https://github.com/Solutionmax/pharos) - Self-hosted status page that runs its own HTTP, TCP and heartbeat checks.
   - [Oxmgr](https://github.com/Vladimir-Urik/OxMgr) - Lightweight Rust process manager and PM2 alternative. 42x faster crash recovery, 19x lower memory usage. Manages Node.js, Python, Go, and any executable on Linux, macOS, and Windows.
 
 ## Service Discovery & Service Mesh


### PR DESCRIPTION
Adds [Pharos](https://github.com/Solutionmax/pharos) under Observability & Monitoring → Status: a self-hosted status page (PHP, AGPL-3.0) that runs its own HTTP, TCP and heartbeat checks and exposes a Cachet 2.x-compatible API.
Disclosure: I am the maintainer of the project.