### PR TITLE
Add seekrit to Secret Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Git Secret](https://github.com/sobolevn/git-secret) - A bash-tool to store your private data inside a git repository.
 - [Infisical](https://github.com/Infisical/infisical) - Open source end-to-end encrypted secrets sync for teams and infrastructure.
 - [Lade](https://github.com/zifeo/lade) - Automatically load secrets from your preferred vault as environment variables.
+- [seekrit](https://seekrit.dev) - End-to-end encrypted secrets manager where the server stores only ciphertext; decryption happens in the CLI, an egress proxy, or read-path SDKs.
 
 ## Security
 


### PR DESCRIPTION
Adds [seekrit](https://seekrit.dev) at the bottom of **Secret Management**.

What distinguishes it from the neighbours already in that section: the server stores only ciphertext. Keys are generated and held client-side, so encryption and decryption happen in the CLI, in an egress proxy, or in a read-path SDK — never in the API.

Delivery paths a DevOps reader would care about:

- `seekrit run -- <cmd>` injects decrypted secrets into a child process's environment (no `.env` on disk)
- a Rust egress proxy that substitutes `{{seekrit:NAME}}` placeholders in outbound requests behind a default-deny allowlist, so a workload can call an API without holding the key
- read-path SDKs for Python, Go, JavaScript and Ruby, a GitHub Action, a Terraform provider, and a Helm chart that syncs into Kubernetes through stock External Secrets Operator

Disclosure: I maintain seekrit. Happy to shorten the description if it runs long for the section's style.