### PR TITLE
Add standup-mr to Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [claws](https://github.com/clawscli/claws) - A terminal UI for managing AWS resources across multiple profiles and regions with vim-style navigation.
 - [purple](https://github.com/erickochen/purple) - SSH client with AWS/GCP/Azure sync, Docker/Podman and SCP transfers.
 - [YAML Validator](https://yamlvalidator.dev) - Online YAML validator, formatter and viewer with JSON Schema support for Kubernetes, Docker Compose, GitHub Actions, and more.
+- [standup-mr](https://github.com/Jubstaaa/standup-mr) - Standup notes from merge request state, with the failed job's error lines.
 
 ## Continuous Integration & Delivery
 


### PR DESCRIPTION
Add **standup-mr** to the **Productivity Tools** category.

- Project: [standup-mr](https://github.com/Jubstaaa/standup-mr)
- npm: https://www.npmjs.com/package/standup-mr
- License: MIT

standup-mr generates a standup note from merge request state rather than from the local git log. A commit log answers "what did I type", which is not the question a standup asks. It reads the GitLab or GitHub API and reports what is ready to merge, what is blocked, what is stale, and what is waiting on your review — and when a pipeline is red it opens the failing job's log and extracts the error lines, so the note says why it is red, not just that it is.

Both providers are first class, including self-hosted GitLab CE/EE and GitHub Enterprise. It runs as a CLI (`npx standup-mr fetch`) and as an MCP server (`npx -y standup-mr mcp`).

The description is 74 characters, ends with a full stop, and the entry was appended to the bottom of the category.