### PR TITLE
Add DevOpsLesson DevOps Engineer Roadmap to DevOps Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 
 - [Roadmap.sh DevOps](https://roadmap.sh/devops): Basic understanding and what you should know to become a *DevOps* Engineer.
 - [Dynamic DevOps Roadmap](https://devopsroadmap.io): A Progressive, Non-Linear, and T-Shaped roadmap that works as a master plan to kickstart your DevOps Engineer career in the Cloud Native era following the Agile MVP style.
+- [DevOpsLesson DevOps Engineer Roadmap](https://devopslesson.com/roadmaps/devops-engineer) - Structured, hands-on roadmap to become a DevOps engineer.
 
 ### Online Platforms
 


### PR DESCRIPTION
Resource: DevOpsLesson DevOps Engineer Roadmap
Category: Resources → DevOps Roadmap Link: https://devopslesson.com/roadmaps/devopsengineer

A free, structured, hands-on roadmap for becoming a DevOps engineer same category as the existing "Roadmap.sh DevOps" and "Dynamic DevOps Roadmap" entries. No signup.

Disclosure: I'm the author of the site. Happy to adjust wording or placement.