### PR TITLE
Add Casdoor to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 
 - [checkov](https://github.com/bridgecrewio/checkov) - Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages.
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC with API for CI/CD integration.
+- [Casdoor](https://github.com/casdoor/casdoor) - Self-hosted SSO and identity provider for OAuth, OIDC and SAML.
 
 ## Sharing
 


### PR DESCRIPTION
**Application:** Casdoor
**Category:** Security
**Project page:** https://github.com/casdoor/casdoor
**License:** Apache-2.0

Casdoor is a self-hosted identity and access management (IAM) / single sign-on (SSO) server written in Go, with a web UI. It acts as an identity provider for OAuth 2.0, OIDC, SAML 2.0, CAS and LDAP, and supports SCIM provisioning, WebAuthn and TOTP/MFA — the piece that centralises authentication for the internal tools in a DevOps stack.

Happy to move this into a dedicated *Identity & Access Management* section instead if you would prefer that categorisation.

- [x] Searched previous suggestions
- [x] Format `[RESOURCE](LINK) - DESCRIPTION.`, description under 80 characters, ends with a full stop
- [x] Single commit for a single category
- [x] No trailing whitespace