### PR TITLE
Add nxip to Automation & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Terrateam](https://terrateam.io) - Open-source alternative to Terraform Cloud/Enterprise, GitOps-first with native GitHub integration and designed for scale, security, and reliability.
 - [Scalr](https://scalr.com/) - Drop-in Terraform Cloud alternative, usage-based pricing, unlimited concurrency.
 - [CloudRay](https://cloudray.io) - Centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.
+- [nxip](https://nx-ip.com) - Terraform-native IPAM that allocates CIDRs from pools rather than by hand.
 
 ## Productivity Tools
 


### PR DESCRIPTION
Adds nxip to Automation & Orchestration, alongside Atlantis and Terrateam.

nxip is an IPAM where address space is allocated from pools rather than picked by hand: you request a size in an environment and region, and a Terraform provider returns a CIDR. Cloud and on-premise, IPv4 and IPv6.

Following the contribution guidelines: single category, single commit, description is 74 characters and ends with a full stop.

- Terraform provider: https://registry.terraform.io/providers/uk-sw/nxip
- Docs: https://nx-ip.com/docs

Thanks for maintaining the list.