### PR TITLE
Add LastPing to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [Zabbix](https://www.zabbix.com/) - Mature and effortless monitoring solution for network monitoring and application monitoring.
 - [Glances](https://github.com/nicolargo/glances) - Monitoring information through a curses or Web based interface.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - Cron monitoring tool.
+- [LastPing](https://lastping.dev) - Dead man's switch for cron jobs, CI/CD pipelines and AI agents.
 - [Bolo](http://bolo.niftylogic.com/) - Building distributed, scalable monitoring systems.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.


### PR DESCRIPTION
Adds **LastPing** to the *Observability & Monitoring* category, next to Healthchecks.

- Application: LastPing — dead man's switch monitoring for cron jobs, CI/CD pipelines and AI agents. A job checks in with one HTTP request after it runs; an incident opens and alerts fire when it goes silent, stalls or fails.
- Category: Observability & Monitoring
- Website: https://lastping.dev
- Open source project page (CLI + MCP server, MIT): https://github.com/tp322d/lastping-app

Format follows CONTRIBUTING: `[RESOURCE](LINK) - DESCRIPTION.`, description under 80 characters, ends with a full stop. One commit, one category.