### PR TITLE
Add dead-mans-switch to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ DevOps is the combination of cultural philosophies, practices, and tools that in
 - [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - Open Source AI assistant that can investigate alerts and find root cause automatically.
 - [Merlinn](https://github.com/merlinn-co/merlinn) - Open-source AI on-call developer.
 - [Middleware](https://middleware.io) - A full-stack cloud observability platform. 
+- [dead-mans-switch](https://github.com/jimy-r/dead-mans-switch) - Alerts on missing success, not on errors, when a scheduled job silently stops.
 - Metrics/Metrics collection
   - [Prometheus](https://prometheus.io/) - Power your metrics and alerting with a leading open-source monitoring solution.
   - [Collectd](https://github.com/collectd/collectd) - The system statistics collection daemon.


### PR DESCRIPTION
Application: dead-mans-switch. Category: Observability & Monitoring. Project page: https://github.com/jimy-r/dead-mans-switch (MIT).

A small CLI that inverts the usual alerting direction for scheduled jobs: each job writes a success sentinel and the checker alerts on missing success rather than on errors, which catches the case where a job silently stops running. I run it over my own scheduled agent jobs.

Description is under 80 characters and ends with a full stop, per the guidelines.
