### PR TITLE
Add Wyrcan Engineering Roadmap to DevOps Roadmap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ as an academic project from University of Tsukuba, under the Apache License 2.0.
 
 - [Roadmap.sh DevOps](https://roadmap.sh/devops): Basic understanding and what you should know to become a *DevOps* Engineer.
 - [Dynamic DevOps Roadmap](https://devopsroadmap.io): A Progressive, Non-Linear, and T-Shaped roadmap that works as a master plan to kickstart your DevOps Engineer career in the Cloud Native era following the Agile MVP style.
+- [Wyrcan Engineering Roadmap](https://github.com/Wyrcan-io/roadmap) - Text-first 12-stage engineering curriculum from Linux to K8s.
 
 ### Online Platforms
 


### PR DESCRIPTION
Adds [Wyrcan Engineering Roadmap](https://github.com/Wyrcan-io/roadmap) to the DevOps Roadmap resources section.

### Details
- **Project:** Wyrcan Engineering Roadmap
- **Category:** DevOps Roadmap
- **Description:** A text-first, practitioner-verified 12-stage engineering curriculum covering Linux internals, Docker, AWS, Terraform, CI/CD, Kubernetes, and Observability.
- Adheres to contributing guidelines: short description under 80 characters, ending with a period.